### PR TITLE
GH-79 Avoid using deprecated `move_to_foreground`

### DIFF
--- a/src/editor/window_wrapper.cpp
+++ b/src/editor/window_wrapper.cpp
@@ -314,7 +314,7 @@ void OrchestratorWindowWrapper::set_margins_enabled(bool p_enabled)
 
 void OrchestratorWindowWrapper::move_to_foreground()
 {
-    _window->move_to_foreground();
+    _window->grab_focus();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #79 