### PR TITLE
GH-130 Improve filtering of All Actions dialog

### DIFF
--- a/src/editor/graph/actions/action_menu_filter.h
+++ b/src/editor/graph/actions/action_menu_filter.h
@@ -67,6 +67,9 @@ struct OrchestratorGraphActionFilter
     /// List of keywords entered by the user.
     Vector<String> keywords;
 
+    /// Target type
+    Variant::Type target_type{ Variant::NIL };
+
     /// A list of class names that you want members for. If an action would produce a
     /// node with a target pin and that pin is incompatible with one of these classes,
     /// then the action is filtered out.

--- a/src/editor/graph/actions/action_registrar.h
+++ b/src/editor/graph/actions/action_registrar.h
@@ -23,7 +23,7 @@
 /// Registrar context
 struct OrchestratorGraphActionRegistrarContext
 {
-    Ref<OScriptNode> script;
+    Ref<OScript> script;
     OrchestratorGraphEdit* graph{ nullptr };
     List<Ref<OrchestratorGraphActionMenuItem>>* list{ nullptr };
     OrchestratorGraphActionFilter* filter{ nullptr };

--- a/src/editor/graph/actions/default_action_registrar.cpp
+++ b/src/editor/graph/actions/default_action_registrar.cpp
@@ -21,7 +21,6 @@
 #include "common/variant_utils.h"
 #include "common/string_utils.h"
 #include "editor/graph/graph_edit.h"
-#include "editor/graph/graph_node_pin.h"
 #include "editor/graph/graph_node_spawner.h"
 #include "script/nodes/script_nodes.h"
 
@@ -45,7 +44,12 @@ void OrchestratorDefaultGraphActionRegistrar::_register_node(const OrchestratorG
     spec.type_icon = "PluginScript";
     spec.graph_compatible = node->is_compatible_with_graph(p_context.graph->get_owning_graph());
 
-    Ref<OrchestratorGraphActionHandler> handler(memnew(OrchestratorGraphNodeSpawnerScriptNode(p_class_name, p_data)));
+    // Initialize the node based on the basic data so that filtration can resolve pin types
+    OScriptNodeInitContext context;
+    context.user_data = p_data;
+    node->initialize(context);
+
+    Ref<OrchestratorGraphActionHandler> handler(memnew(OrchestratorGraphNodeSpawnerScriptNode(p_class_name, p_data, node)));
     p_context.list->push_back(memnew(OrchestratorGraphActionMenuItem(spec, handler)));
 }
 

--- a/src/editor/graph/graph_edit.cpp
+++ b/src/editor/graph/graph_edit.cpp
@@ -799,6 +799,8 @@ void OrchestratorGraphEdit::_on_attempt_connection_from_empty(const StringName& 
     filter.context.pins.push_back(pin);
 
     ResolvedType resolved_type = pin->resolve_type();
+    filter.target_type = resolved_type.type;
+
     if (resolved_type.object)
     {
         // When a resolved object isp provided, it takes precedence
@@ -830,6 +832,8 @@ void OrchestratorGraphEdit::_on_attempt_connection_to_empty(const StringName& p_
     filter.context.pins.push_back(pin);
 
     ResolvedType resolved_type = pin->resolve_type();
+    filter.target_type = resolved_type.type;
+
     if (resolved_type.object)
     {
         // When a resolved object is provided, it takes precedence

--- a/src/editor/graph/graph_node_spawner.h
+++ b/src/editor/graph/graph_node_spawner.h
@@ -18,6 +18,7 @@
 #define ORCHESTRATOR_GRAPH_NODE_SPAWNER_H
 
 #include "actions/action_menu_filter.h"
+#include "script/node.h"
 
 /// Base class for all OrchestratorGraphNode spawner action handlers
 class OrchestratorGraphNodeSpawner : public OrchestratorGraphActionHandler
@@ -155,11 +156,9 @@ class OrchestratorGraphNodeSpawnerCallScriptFunction : public OrchestratorGraphN
 protected:
     OrchestratorGraphNodeSpawnerCallScriptFunction() = default;
 
-    MethodInfo _method;
-
 public:
     OrchestratorGraphNodeSpawnerCallScriptFunction(const MethodInfo& p_method)
-        : _method(p_method)
+        : OrchestratorGraphNodeSpawnerCallMemberFunction(p_method)
     {
     }
 
@@ -255,6 +254,7 @@ public:
 
     //~ Begin OrchestratorGraphNodeSpawner Interface
     void execute(OrchestratorGraphEdit* p_graph, const Vector2& p_position) override;
+    bool is_filtered(const OrchestratorGraphActionFilter& p_filter, const OrchestratorGraphActionSpec& p_spec) override;
     //~ End OrchestratorGraphNodeSpawner Interface
 };
 
@@ -276,6 +276,7 @@ public:
 
     //~ Begin OrchestratorGraphNodeSpawner Interface
     void execute(OrchestratorGraphEdit* p_graph, const Vector2& p_position) override;
+    bool is_filtered(const OrchestratorGraphActionFilter& p_filter, const OrchestratorGraphActionSpec& p_spec) override;
     //~ End OrchestratorGraphNodeSpawner Interface
 };
 
@@ -291,11 +292,13 @@ protected:
 
     StringName _node_name;
     Dictionary _data;
+    Ref<OScriptNode> _node;
 
 public:
-    OrchestratorGraphNodeSpawnerScriptNode(const StringName& p_node_name, const Dictionary& p_data)
+    OrchestratorGraphNodeSpawnerScriptNode(const StringName& p_node_name, const Dictionary& p_data, const Ref<OScriptNode>& p_node)
         : _node_name(p_node_name)
         , _data(p_data)
+        , _node(p_node)
     {
     }
 


### PR DESCRIPTION
Fixes #130 

- [x] Correctly filter by pin types, including script nodes
- [x] Property Get and Set are correctly filtered based on keywords
- [x] Filter script functions and signals by argument types when pin is output
- [x] Filter script functions by output types when pin is input
- [x] Filter script variable get/set based on pin input/output direction
- [x] Fixed bug in setting script object on filter criteria