### PR TITLE
GH-132 Improved graph node rendering

### DIFF
--- a/src/editor/graph/graph_node.h
+++ b/src/editor/graph/graph_node.h
@@ -21,11 +21,7 @@
 
 #include <godot_cpp/classes/graph_node.hpp>
 #include <godot_cpp/classes/input_event.hpp>
-#include <godot_cpp/classes/label.hpp>
 #include <godot_cpp/classes/popup_menu.hpp>
-#include <godot_cpp/classes/style_box_flat.hpp>
-#include <godot_cpp/classes/texture_rect.hpp>
-#include <godot_cpp/templates/hash_map.hpp>
 
 using namespace godot;
 
@@ -172,16 +168,9 @@ protected:
     /// Update the node's styles
     void _update_styles();
 
-    /// Creates a style based on a specific color.
-    /// @param p_existing_name the existing style to clone from
-    /// @param p_color the color to be applied
-    /// @param p_titlebar whether to treat the style box as a titlebar or panel border
-    Ref<StyleBoxFlat> _make_colored_style(const String& p_existing_name, const Color& p_color, bool p_titlebar = false);
-
-    /// Creates a style based on node selection color.
-    /// @param p_existing_name the existing style to clone from
-    /// @param p_titlebar whether to treat the style box as a titlebar or panel border
-    Ref<StyleBoxFlat> _make_selected_style(const String& p_existing_name, bool p_titlebar = false);
+    /// Get the selection color
+    /// @return the border color for when nodes are selected
+    Color _get_selection_color() const;
 
     /// Called by various callbacks to update node attributes
     void _update_node_attributes();
@@ -215,7 +204,7 @@ private:
     /// Called when a pin is connected
     /// @param p_type pin type
     /// @param p_index the pin index
-    void _on_pin_connected(int p_Type, int p_index);
+    void _on_pin_connected(int p_type, int p_index);
 
     /// Called when a pin is disconnected
     /// @param p_type pin type

--- a/src/editor/script_view.cpp
+++ b/src/editor/script_view.cpp
@@ -23,8 +23,8 @@
 #include "script_view.h"
 
 #include <godot_cpp/classes/input_event_mouse_button.hpp>
+#include <godot_cpp/classes/label.hpp>
 #include <godot_cpp/classes/margin_container.hpp>
-#include <godot_cpp/classes/method_tweener.hpp>
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/panel_container.hpp>
 #include <godot_cpp/classes/resource_saver.hpp>
@@ -32,9 +32,8 @@
 #include <godot_cpp/classes/scene_tree_timer.hpp>
 #include <godot_cpp/classes/scroll_container.hpp>
 #include <godot_cpp/classes/style_box_flat.hpp>
+#include <godot_cpp/classes/texture_rect.hpp>
 #include <godot_cpp/classes/theme.hpp>
-#include <godot_cpp/classes/theme_db.hpp>
-#include <godot_cpp/classes/tween.hpp>
 #include <godot_cpp/classes/v_box_container.hpp>
 #include <godot_cpp/templates/hash_map.hpp>
 #include <godot_cpp/templates/vector.hpp>


### PR DESCRIPTION
Fixes #132 

Godot 4.3.dev4 introduced some changes to how `GraphNode` objects are rendered.  These changes guarantee that all script nodes in Orchestrator are rendered the same way regardless of whether Godot 4.2 or 4.3 is used.