### PR TITLE
GH-222 Allow some constant/singleton names be searchable

### DIFF
--- a/src/editor/graph/actions/default_action_registrar.cpp
+++ b/src/editor/graph/actions/default_action_registrar.cpp
@@ -35,11 +35,14 @@ void OrchestratorDefaultGraphActionRegistrar::_register_node(const OrchestratorG
 
     PackedStringArray name_parts = p_category.split("/");
 
+    PackedStringArray keywords = node->get_keywords();
+    keywords.append_array(name_parts);
+
     OrchestratorGraphActionSpec spec;
     spec.category = "Script/Nodes/" + p_category;
     spec.tooltip = node->get_tooltip_text();
     spec.text = name_parts[int(name_parts.size()) - 1].capitalize();
-    spec.keywords = StringUtils::join(",", name_parts);
+    spec.keywords = StringUtils::join(",", keywords);
     spec.icon = node->get_icon();
     spec.type_icon = "PluginScript";
     spec.graph_compatible = node->is_compatible_with_graph(p_context.graph->get_owning_graph());

--- a/src/script/node.h
+++ b/src/script/node.h
@@ -159,7 +159,7 @@ public:
 
     /// Get keywords that should also be matched when performing action lookups
     /// @return keywords that are additional matches beyond the node name
-    virtual String get_keywords() const { return {}; }
+    virtual PackedStringArray get_keywords() const { return {}; }
 
     /// Get all node-specific actions that will be appended to the node context menu.
     /// @param p_action_list the list of actions to append actions

--- a/src/script/nodes/constants/constants.cpp
+++ b/src/script/nodes/constants/constants.cpp
@@ -181,6 +181,11 @@ String OScriptNodeGlobalConstant::get_icon() const
     return "MemberConstant";
 }
 
+PackedStringArray OScriptNodeGlobalConstant::get_keywords() const
+{
+    return ExtensionDB::get_global_enum_value_names();
+}
+
 OScriptNodeInstance* OScriptNodeGlobalConstant::instantiate(OScriptInstance* p_instance)
 {
     OScriptNodeGlobalConstantInstance* i = memnew(OScriptNodeGlobalConstantInstance);
@@ -256,6 +261,11 @@ String OScriptNodeMathConstant::get_node_title() const
 String OScriptNodeMathConstant::get_icon() const
 {
     return "MemberConstant";
+}
+
+PackedStringArray OScriptNodeMathConstant::get_keywords() const
+{
+    return ExtensionDB::get_math_constant_names();
 }
 
 OScriptNodeInstance* OScriptNodeMathConstant::instantiate(OScriptInstance* p_instance)

--- a/src/script/nodes/constants/constants.h
+++ b/src/script/nodes/constants/constants.h
@@ -57,6 +57,7 @@ public:
     String get_tooltip_text() const override;
     String get_node_title() const override;
     String get_icon() const override;
+    PackedStringArray get_keywords() const override;
     OScriptNodeInstance* instantiate(OScriptInstance* p_instance) override;
     void initialize(const OScriptNodeInitContext& p_context) override;
     bool validate_node_during_build() const override;
@@ -83,6 +84,7 @@ public:
     String get_tooltip_text() const override;
     String get_node_title() const override;
     String get_icon() const override;
+    PackedStringArray get_keywords() const override;
     OScriptNodeInstance* instantiate(OScriptInstance* p_instance) override;
     bool validate_node_during_build() const override;
     //~ End OScriptNodeInterface

--- a/src/script/nodes/utilities/engine_singleton.cpp
+++ b/src/script/nodes/utilities/engine_singleton.cpp
@@ -86,6 +86,11 @@ String OScriptNodeEngineSingleton::get_icon() const
     return "GodotMonochrome";
 }
 
+PackedStringArray OScriptNodeEngineSingleton::get_keywords() const
+{
+    return Engine::get_singleton()->get_singleton_list();
+}
+
 StringName OScriptNodeEngineSingleton::resolve_type_class(const Ref<OScriptNodePin>& p_pin) const
 {
     return _singleton;

--- a/src/script/nodes/utilities/engine_singleton.h
+++ b/src/script/nodes/utilities/engine_singleton.h
@@ -40,6 +40,7 @@ public:
     String get_node_title() const override;
     String get_node_title_color_name() const override { return "variable"; }
     String get_icon() const override;
+    PackedStringArray get_keywords() const override;
     StringName resolve_type_class(const Ref<OScriptNodePin>& p_pin) const override;
     OScriptNodeInstance* instantiate(OScriptInstance* p_instance) override;
     //~ End OScriptNode Interface


### PR DESCRIPTION
Fixes #222 

@GhostNr1, so this addresses some of the constants to be searchable; however, it doesn't satisfy all.  For example, this allows global constants, math constants, and singleton names to be searchable.

The issue right now with the other types is that the list of items is quite vast and depend on some context, i.e. an object type or class type, and I think ideally we may want to think about creating a cache for these.  If you think the above are satisfactory for now, we can certainly go with this; however, if you want a more flushed solution, then we'll need to revisit the class/type based constants.