### PR TITLE
GH-156 Collapse nodes to function and expand node feature

### DIFF
--- a/src/common/callable_lambda.h
+++ b/src/common/callable_lambda.h
@@ -1,0 +1,113 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef ORCHESTRATOR_CALLABLE_LAMBDA_H
+#define ORCHESTRATOR_CALLABLE_LAMBDA_H
+
+#include <utility>
+
+#include <godot_cpp/core/object.hpp>
+#include <godot_cpp/variant/callable_custom.hpp>
+
+namespace callable_internal
+{
+    using namespace godot;
+
+    template<typename T>
+    struct function_traits : public function_traits<decltype(&T::operator())>
+    {};
+
+    template <typename ClassType, typename ReturnType, typename... Args>
+    struct function_traits<ReturnType(ClassType::*)(Args...) const>
+    {
+        using result_type = ReturnType;
+        using arg_tuple = std::tuple<Args...>;
+        static constexpr auto arity = sizeof...(Args);
+    };
+
+    template<class T>
+    struct ExpandPack;
+
+    template<class ...Args>
+    struct ExpandPack<std::tuple<Args...>> {
+        template<class L, std::size_t ...Is>
+        _FORCE_INLINE_ static void call(L&& l, const Variant **p_arguments, int p_argcount, Variant &r_return_value,
+                                        GDExtensionCallError &r_call_error, IndexSequence<Is...>) {
+            #ifdef DEBUG_ENABLED
+            if ((size_t)p_argcount > sizeof...(Args)) {
+                r_call_error.error = GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS;
+                r_call_error.expected = (int32_t)sizeof...(Args);
+                return;
+            }
+
+            if ((size_t)p_argcount < sizeof...(Args)) {
+                r_call_error.error = GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS;
+                r_call_error.expected = (int32_t)sizeof...(Args);
+                return;
+            }
+            #endif
+
+            r_call_error.error = GDEXTENSION_CALL_OK;
+
+            #ifdef DEBUG_METHODS_ENABLED
+            l(VariantCasterAndValidate<Args>::cast(p_arguments, Is, r_call_error)...);
+            #else
+            l(VariantCaster<Args>::cast(*p_arguments[Is])...);
+            #endif
+            (void)(p_arguments); // Avoid warning.
+        }
+    };
+
+    template<class Lambda>
+    class CallableCustomLambda : public CallableCustom
+    {
+        Lambda _lambda;
+        Object* _instance;
+
+    public:
+        //~ Begin CallableCustom Interface
+        uint32_t hash() const override { return (intptr_t) this; }
+        String get_as_text() const override { return "CallableCustomLambda"; }
+        CompareEqualFunc get_compare_equal_func() const override { return [](const CallableCustom* a, const CallableCustom* b) { return a->hash() == b->hash(); }; }
+        CompareLessFunc get_compare_less_func() const override { return [](const CallableCustom* a, const CallableCustom* b) { return a->hash() < b->hash(); }; }
+        bool is_valid() const override { return _instance != nullptr; }
+        ObjectID get_object() const override { return ObjectID(); }
+        void call(const Variant** p_args, int p_argcount, Variant& r_ret, GDExtensionCallError& r_error) const override
+        {
+            using traits = function_traits<Lambda>;
+            using E = ExpandPack<typename traits::arg_tuple>;
+            E::call(_lambda, p_args, p_argcount, r_ret, r_error, BuildIndexSequence<traits::arity>{});
+        }
+        //~ End CallableCustom Interface
+
+        /// Constructor
+        /// @param p_instance the instance the callable is invoked upon
+        /// @param p_lambda the lambda function to call
+        CallableCustomLambda(Object* p_instance, Lambda&& p_lambda)
+            : _lambda(p_lambda)
+            , _instance(p_instance)
+        {};
+    };
+}
+
+template<class Lambda>
+godot::Callable callable_mp_lambda(godot::Object* p_instance, Lambda&& p_lambda)
+{
+    auto* ccl = memnew(callable_internal::CallableCustomLambda(p_instance, std::forward<Lambda>(p_lambda)));
+    return godot::Callable(ccl);
+}
+
+#endif

--- a/src/common/name_utils.cpp
+++ b/src/common/name_utils.cpp
@@ -1,0 +1,40 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "common/name_utils.h"
+
+#include <limits>
+
+#include <godot_cpp/variant/variant.hpp>
+
+namespace NameUtils
+{
+    String create_unique_name(const String& p_prefix, const PackedStringArray& p_names)
+    {
+        if (!p_names.has(p_prefix))
+            return p_prefix;
+
+        for (int i = 0; i < std::numeric_limits<int>::max(); i++)
+        {
+            const String name = vformat("%s_%s", p_prefix, i);
+            if (!p_names.has(name))
+                return name;
+        }
+
+        WARN_PRINT("Failed to create a unique name for prefix: " + p_prefix);
+        return {};
+    }
+}

--- a/src/common/name_utils.h
+++ b/src/common/name_utils.h
@@ -1,0 +1,33 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef ORCHESTRATOR_NAME_UTILS_H
+#define ORCHESTRATOR_NAME_UTILS_H
+
+#include <godot_cpp/variant/packed_string_array.hpp>
+
+using namespace godot;
+
+namespace NameUtils
+{
+    /// Create a unique name based on the prefix and not in the names array
+    /// @param p_prefix the prefix
+    /// @param p_names the existing names
+    /// @return the unique name
+    String create_unique_name(const String& p_prefix, const PackedStringArray& p_names = PackedStringArray());
+}
+
+#endif // ORCHESTRATOR_NAME_UTILS_H

--- a/src/common/scene_utils.cpp
+++ b/src/common/scene_utils.cpp
@@ -46,8 +46,8 @@ namespace SceneUtils
             const bool instantiable = ClassDB::can_instantiate(p_class_name);
             if (ClassDB::is_parent_class(p_class_name, "Node"))
                 return vbox->get_theme_icon(instantiable ? "Node" : "NodeDisabled", "EditorIcons");
-            else
-                return vbox->get_theme_icon(instantiable ? "Object" : "ObjectDisabled", "EditorIcons");
+
+            return vbox->get_theme_icon(instantiable ? "Object" : "ObjectDisabled", "EditorIcons");
         }
 
         return nullptr;
@@ -63,6 +63,12 @@ namespace SceneUtils
     {
         VBoxContainer* vbox = OrchestratorPlugin::get_singleton()->get_editor_interface()->get_editor_main_screen();
         return vbox->get_theme_icon(p_icon_name, "EditorIcons");
+    }
+
+    Ref<StyleBox> get_editor_style(const String& p_style_name)
+    {
+        VBoxContainer* vbox = OrchestratorPlugin::get_singleton()->get_editor_interface()->get_editor_main_screen();
+        return vbox->get_theme_stylebox(p_style_name, "EditorStyles");
     }
 
     Ref<Font> get_editor_font(const String& p_font_name)

--- a/src/common/scene_utils.h
+++ b/src/common/scene_utils.h
@@ -22,6 +22,7 @@
 #include <godot_cpp/classes/margin_container.hpp>
 #include <godot_cpp/classes/node.hpp>
 #include <godot_cpp/classes/script.hpp>
+#include <godot_cpp/classes/style_box.hpp>
 #include <godot_cpp/classes/texture2d.hpp>
 #include <godot_cpp/templates/vector.hpp>
 
@@ -39,6 +40,11 @@ namespace SceneUtils
     /// @param p_icon_name the editor icon to load
     /// @return a reference to the texture or an invalid reference if the texture isn't loaded
     Ref<Texture2D> get_editor_icon(const String& p_icon_name);
+
+    /// Gets an editor style by name
+    /// @param p_style_name the style name
+    /// @return a reference to the editor stylebox or an invalid reference if not found
+    Ref<StyleBox> get_editor_style(const String& p_style_name);
 
     /// Get an editor font
     /// @param p_font_name the font name

--- a/src/editor/component_panels/component_panel.cpp
+++ b/src/editor/component_panels/component_panel.cpp
@@ -1,0 +1,350 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "editor/component_panels/component_panel.h"
+
+#include "common/callable_lambda.h"
+#include "common/name_utils.h"
+#include "common/scene_utils.h"
+#include "plugin/plugin.h"
+
+#include <godot_cpp/classes/accept_dialog.hpp>
+#include <godot_cpp/classes/button.hpp>
+#include <godot_cpp/classes/confirmation_dialog.hpp>
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/h_box_container.hpp>
+#include <godot_cpp/classes/input_event_mouse_button.hpp>
+#include <godot_cpp/classes/label.hpp>
+#include <godot_cpp/classes/panel_container.hpp>
+#include <godot_cpp/classes/popup_menu.hpp>
+#include <godot_cpp/classes/scene_tree.hpp>
+#include <godot_cpp/classes/scene_tree_timer.hpp>
+#include <godot_cpp/classes/style_box_flat.hpp>
+#include <godot_cpp/classes/texture_rect.hpp>
+#include <godot_cpp/classes/theme.hpp>
+#include <godot_cpp/classes/tree.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+void OrchestratorScriptComponentPanel::_toggle()
+{
+    _expanded = !_expanded;
+    _update_collapse_button_icon();
+    _tree->set_visible(_expanded);
+}
+
+void OrchestratorScriptComponentPanel::_tree_add_item()
+{
+    const String new_name = _create_unique_name_with_prefix(_get_unique_name_prefix());
+    if (_handle_add_new_item(new_name))
+    {
+        update();
+        _find_child_and_activate(new_name);
+    }
+}
+
+void OrchestratorScriptComponentPanel::_tree_item_activated()
+{
+    TreeItem* item = _tree->get_selected();
+    ERR_FAIL_COND_MSG(!item, "Cannot activate when no item selected");
+
+    _handle_item_activated(item);
+}
+
+void OrchestratorScriptComponentPanel::_tree_item_edited()
+{
+    TreeItem* item = _tree->get_selected();
+    ERR_FAIL_COND_MSG(!item, "Cannot edit item when no item selected");
+
+    const String old_name = item->get_meta("__name");
+    const String new_name = item->get_text(0);
+
+    // Nothing to edit if they're identical
+    if (old_name.match(new_name))
+        return;
+
+    _handle_item_renamed(old_name, new_name);
+
+    update();
+}
+
+void OrchestratorScriptComponentPanel::_tree_item_mouse_selected(const Vector2& p_position, int p_button)
+{
+    if (p_button != MOUSE_BUTTON_RIGHT)
+        return;
+
+    TreeItem* item = _tree->get_selected();
+    if (!item)
+        return;
+
+    _context_menu->clear();
+    _context_menu->reset_size();
+
+    if (_populate_context_menu(item))
+    {
+        _context_menu->set_position(_tree->get_screen_position() + p_position);
+        _context_menu->reset_size();
+        _context_menu->popup();
+    }
+}
+
+void OrchestratorScriptComponentPanel::_remove_confirmed()
+{
+    if (_tree->get_selected())
+    {
+        OrchestratorPlugin::get_singleton()->get_editor_interface()->inspect_object(nullptr);
+        _handle_remove(_tree->get_selected());
+
+        update();
+    }
+}
+
+void OrchestratorScriptComponentPanel::_tree_item_button_clicked(TreeItem* p_item, int p_column, int p_id, int p_mouse_button)
+{
+    _handle_button_clicked(p_item, p_column, p_id, p_mouse_button);
+}
+
+Variant OrchestratorScriptComponentPanel::_tree_drag_data(const Vector2& p_position)
+{
+    const Dictionary data = _handle_drag_data(p_position);
+    if (data.keys().is_empty())
+        return {};
+
+    PanelContainer* container = memnew(PanelContainer);
+    container->set_anchors_preset(PRESET_TOP_LEFT);
+    container->set_v_size_flags(SIZE_SHRINK_BEGIN);
+
+    HBoxContainer* hbc = memnew(HBoxContainer);
+    hbc->set_v_size_flags(SIZE_SHRINK_CENTER);
+    container->add_child(hbc);
+
+    TextureRect* rect = memnew(TextureRect);
+    rect->set_texture(_tree->get_selected()->get_icon(0));
+    rect->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
+    rect->set_h_size_flags(SIZE_SHRINK_CENTER);
+    rect->set_v_size_flags(SIZE_SHRINK_CENTER);
+    hbc->add_child(rect);
+
+    Label* label = memnew(Label);
+    label->set_text(_tree->get_selected()->get_text(0));
+    hbc->add_child(label);
+
+    set_drag_preview(container);
+    return data;
+}
+
+void OrchestratorScriptComponentPanel::_update_theme()
+{
+    if (!_theme_changing)
+        return;
+
+    Ref<Theme> theme = OrchestratorPlugin::get_singleton()->get_editor_interface()->get_editor_theme();
+    if (theme.is_valid() && _panel)
+    {
+        Ref<StyleBoxFlat> sb = theme->get_stylebox("panel", "ItemList")->duplicate();
+        sb->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+        sb->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+        _panel->add_theme_stylebox_override("panel", sb);
+    }
+
+    Ref<StyleBoxFlat> sb = _tree->get_theme_stylebox("panel");
+    if (sb.is_valid())
+    {
+        Ref<StyleBoxFlat> new_style = sb->duplicate();
+        new_style->set_corner_radius(CORNER_TOP_LEFT, 0);
+        new_style->set_corner_radius(CORNER_TOP_RIGHT, 0);
+        _tree->add_theme_stylebox_override("panel", new_style);
+    }
+
+    queue_redraw();
+
+    _theme_changing = false;
+}
+
+void OrchestratorScriptComponentPanel::_clear_tree()
+{
+    _tree->clear();
+    _tree->create_item();
+}
+
+void OrchestratorScriptComponentPanel::_update_collapse_button_icon()
+{
+    const String icon_name = _expanded ? "CodeFoldDownArrow" : "CodeFoldedRightArrow";
+    _collapse_button->set_button_icon(SceneUtils::get_editor_icon(icon_name));
+}
+
+void OrchestratorScriptComponentPanel::_show_notification(const String& p_message)
+{
+    _notify->set_text(p_message);
+    _notify->reset_size();
+    _notify->popup_centered();
+}
+
+void OrchestratorScriptComponentPanel::_confirm_removal(TreeItem* p_item)
+{
+    _confirm->set_text(_get_remove_confirm_text(p_item) + "\n\nDo you want to continue?");
+    _confirm->set_ok_button_text("Yes");
+    _confirm->set_cancel_button_text("No");
+    _confirm->reset_size();
+    _confirm->popup_centered();
+}
+
+String OrchestratorScriptComponentPanel::_create_unique_name_with_prefix(const String& p_prefix)
+{
+    return NameUtils::create_unique_name(p_prefix, _get_existing_names());
+}
+
+bool OrchestratorScriptComponentPanel::_find_child_and_activate(const String& p_name, bool p_edit)
+{
+    TreeItem* root = _tree->get_root();
+
+    for (int i = 0; i < root->get_child_count(); i++)
+    {
+        if (TreeItem* child = Object::cast_to<TreeItem>(root->get_child(i)))
+        {
+            if (child->get_text(0).match(p_name))
+            {
+                emit_signal("scroll_to_item", child);
+                _tree->call_deferred("set_selected", child, 0);
+
+                if (p_edit)
+                {
+                    Ref<SceneTreeTimer> timer = get_tree()->create_timer(0.1f);
+                    if (timer.is_valid())
+                        timer->connect("timeout", callable_mp(_tree, &Tree::edit_selected).bind(true));
+                }
+
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+void OrchestratorScriptComponentPanel::_gui_input(const Ref<InputEvent>& p_event)
+{
+    const Ref<InputEventMouseButton> mb = p_event;
+    if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT)
+    {
+        _toggle();
+        get_viewport()->set_input_as_handled();
+    }
+}
+
+void OrchestratorScriptComponentPanel::update()
+{
+    if (_expanded)
+    {
+        // A simple hack to redraw the tree based on content height
+        _tree->set_visible(false);
+        _tree->set_visible(true);
+    }
+}
+
+void OrchestratorScriptComponentPanel::find_and_edit(const String& p_item_name)
+{
+    _find_child_and_activate(p_item_name, true);
+}
+
+void OrchestratorScriptComponentPanel::_notification(int p_what)
+{
+    if (p_what == NOTIFICATION_READY)
+    {
+        _panel_hbox = memnew(HBoxContainer);
+        _panel_hbox->set_h_size_flags(SIZE_EXPAND_FILL);
+        _panel_hbox->set_tooltip_text(SceneUtils::create_wrapped_tooltip_text(_get_tooltip_text()));
+
+        _collapse_button = memnew(Button);
+        _collapse_button->set_focus_mode(FOCUS_NONE);
+        _collapse_button->set_flat(true);
+        _update_collapse_button_icon();
+        _panel_hbox->add_child(_collapse_button);
+
+        Label* label = memnew(Label);
+        label->set_text(_title);
+        label->set_h_size_flags(SIZE_EXPAND_FILL);
+        _panel_hbox->add_child(label);
+
+        Button* add_button = memnew(Button);
+        add_button->set_focus_mode(FOCUS_NONE);
+        add_button->set_button_icon(SceneUtils::get_editor_icon("Add"));
+        add_button->set_tooltip_text("Add a new " + _get_item_name());
+        _panel_hbox->add_child(add_button);
+
+        _panel = memnew(PanelContainer);
+        _panel->set_mouse_filter(MOUSE_FILTER_PASS);
+        _panel->add_child(_panel_hbox);
+        add_child(_panel);
+
+        _tree = memnew(Tree);
+        _tree->set_columns(1);
+        _tree->set_allow_rmb_select(true);
+        _tree->set_select_mode(Tree::SELECT_ROW);
+        _tree->set_h_scroll_enabled(false);
+        _tree->set_v_scroll_enabled(false);
+        _tree->set_h_size_flags(SIZE_EXPAND_FILL);
+        _tree->set_v_size_flags(SIZE_FILL);
+        _tree->set_hide_root(true);
+        _tree->set_focus_mode(FOCUS_NONE);
+        _tree->create_item()->set_text(0, "Root"); // creates the root item
+        add_child(_tree);
+
+        _context_menu = memnew(PopupMenu);
+        add_child(_context_menu);
+
+        _confirm = memnew(ConfirmationDialog);
+        _confirm->set_title("Please confirm...");
+        _confirm->get_label()->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+        add_child(_confirm);
+
+        _notify = memnew(AcceptDialog);
+        _notify->set_title("Message");
+        add_child(_notify);
+
+        // Connections
+        _collapse_button->connect("pressed", callable_mp(this, &OrchestratorScriptComponentPanel::_toggle));
+        add_button->connect("pressed", callable_mp(this, &OrchestratorScriptComponentPanel::_tree_add_item));
+        _tree->connect("item_activated", callable_mp(this, &OrchestratorScriptComponentPanel::_tree_item_activated));
+        _tree->connect("item_edited", callable_mp(this, &OrchestratorScriptComponentPanel::_tree_item_edited));
+        _tree->connect("item_selected", callable_mp_lambda(this, [&] { _handle_item_selected(); }));
+        _tree->connect("item_mouse_selected", callable_mp(this, &OrchestratorScriptComponentPanel::_tree_item_mouse_selected));
+        _tree->connect("item_collapsed", callable_mp_lambda(this, [&]([[maybe_unused]] TreeItem* i) { update(); }));
+        _tree->connect("button_clicked", callable_mp(this, &OrchestratorScriptComponentPanel::_tree_item_button_clicked));
+        _context_menu->connect("id_pressed", callable_mp_lambda(this, [&](int id) { _handle_context_menu(id); }));
+        _confirm->connect("confirmed", callable_mp(this, &OrchestratorScriptComponentPanel::_remove_confirmed));
+
+        _tree->set_drag_forwarding(callable_mp(this, &OrchestratorScriptComponentPanel::_tree_drag_data), Callable(), Callable());
+    }
+    else if (p_what == NOTIFICATION_THEME_CHANGED)
+    {
+        _theme_changing = true;
+        callable_mp(this, &OrchestratorScriptComponentPanel::_update_theme).call_deferred();
+    }
+}
+
+void OrchestratorScriptComponentPanel::_bind_methods()
+{
+    ADD_SIGNAL(MethodInfo("scroll_to_item", PropertyInfo(Variant::OBJECT, "item")));
+}
+
+OrchestratorScriptComponentPanel::OrchestratorScriptComponentPanel(const String& p_title, const Ref<OScript>& p_script)
+    : _title(p_title)
+    , _script(p_script)
+{
+    set_v_size_flags(SIZE_SHRINK_BEGIN);
+    set_h_size_flags(SIZE_EXPAND_FILL);
+    add_theme_constant_override("separation", 0);
+    set_custom_minimum_size(Vector2i(165, 0));
+}

--- a/src/editor/component_panels/component_panel.h
+++ b/src/editor/component_panels/component_panel.h
@@ -1,0 +1,192 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef ORCHESTRATOR_SCRIPT_COMPONENT_PANEL_H
+#define ORCHESTRATOR_SCRIPT_COMPONENT_PANEL_H
+
+#include "script/script.h"
+
+#include <godot_cpp/classes/input_event.hpp>
+#include <godot_cpp/classes/v_box_container.hpp>
+
+using namespace godot;
+
+/// Forward declarations
+namespace godot
+{
+    class AcceptDialog;
+    class Button;
+    class ConfirmationDialog;
+    class HBoxContainer;
+    class Label;
+    class PanelContainer;
+    class PopupMenu;
+    class Tree;
+    class TreeItem;
+}
+
+/// A component panel for the Orchestrator Script editor.
+class OrchestratorScriptComponentPanel : public VBoxContainer
+{
+    GDCLASS(OrchestratorScriptComponentPanel, VBoxContainer);
+    static void _bind_methods();
+
+protected:
+    String _title;                            //! Title
+    Ref<OScript> _script;                     //! The script
+    PanelContainer* _panel{ nullptr };        //! Panel container
+    HBoxContainer* _panel_hbox{ nullptr };    //! Panel HBox container
+    Tree* _tree{ nullptr };                   //! The tree list
+    Button* _collapse_button{ nullptr };      //! The collapse button
+    PopupMenu* _context_menu{ nullptr };      //! Context menu
+    ConfirmationDialog* _confirm{ nullptr };  //! Confirmation dialog
+    AcceptDialog* _notify{ nullptr };         //! Notification dialog
+    bool _expanded{ true };                   //! Whether the section is currently expanded
+    bool _theme_changing{ false };            //! Whether the theme is being changed
+
+    //~ Begin Signal handlers
+    void _toggle();
+    void _tree_add_item();
+    void _tree_item_activated();
+    void _tree_item_edited();
+    void _tree_item_mouse_selected(const Vector2& p_position, int p_button);
+    void _remove_confirmed();
+    void _tree_item_button_clicked(TreeItem* p_item, int p_column, int p_id, int p_mouse_button);
+    Variant _tree_drag_data(const Vector2& p_position);
+    //~ End Signal handlers
+
+    /// Updates the control's theme.
+    void _update_theme();
+
+    /// Clears the tree of all items but the root.
+    void _clear_tree();
+
+    /// Updates the state of the collapse button.
+    void _update_collapse_button_icon();
+
+    /// Notifies the user of a message.
+    /// @param p_message the text to notify
+    void _show_notification(const String& p_message);
+
+    /// Presents the user a dialog, confirming the removal of the tree item.
+    /// @param p_item the item to be removed, should not be null
+    void _confirm_removal(TreeItem* p_item);
+
+    /// Creates a unique name in the tree with the given prefix.
+    /// This is useful to guarantee that all new items have a unique name.
+    /// @param p_prefix the prefix to use
+    /// @return the new unique name
+    String _create_unique_name_with_prefix(const String& p_prefix);
+
+    /// Finds the specified child in the tree with text that matches the given name.
+    /// @param p_name the text to find and activate in the tree control
+    /// @param p_edit true if the item should be edited after activation, false otherwise
+    /// @return true if the item is found and activated, false otherwise
+    bool _find_child_and_activate(const String& p_name, bool p_edit = true);
+
+    /// Get the panel's horizontal box control
+    /// @return the HBoxContainer child of the top panel, never null
+    HBoxContainer* _get_panel_hbox() const { return _panel_hbox; }
+
+    /// Get the prefix used for creating new elements
+    /// @return the new unique name prefix
+    virtual String _get_unique_name_prefix() const { return "item"; }
+
+    /// Get all the existing names for a given element.
+    /// @return packed string array of all existing object names
+    virtual PackedStringArray _get_existing_names() const { return {}; }
+
+    /// Get the tooltip text for the panel header.
+    /// @return the tooltip text to be shown.
+    virtual String _get_tooltip_text() const { return {}; }
+
+    /// Get the confirmation dialog text to show on item removal.
+    /// @param p_item the item to be removed
+    /// @return the text to show in the dialog
+    virtual String _get_remove_confirm_text(TreeItem* p_item) const { return {}; }
+
+    /// Get the item name, used for the add button tooltip
+    /// @return the name of what items are called in the tree view.
+    virtual String _get_item_name() const { return "item"; }
+
+    /// Populates the context menu with options
+    /// @param p_item the tree item to create a context menu for, never null
+    /// @return true if the context menu is to be shown, false to not show the popup
+    virtual bool _populate_context_menu(TreeItem* p_item) { return false; }
+
+    /// Handles context menu selections.
+    /// @param p_id the menu id selected
+    virtual void _handle_context_menu(int p_id) { }
+
+    /// Handles adding new items to the tree
+    /// @param p_name the item's name to be added
+    /// @return true if the item added, false otherwise
+    virtual bool _handle_add_new_item(const String& p_name) { return false; }
+
+    /// Handles when an item is activated
+    /// @param p_item the activated item, never null
+    virtual void _handle_item_activated(TreeItem* p_item) { }
+
+    /// Handles when an item is selected
+    virtual void _handle_item_selected() { }
+
+    /// Handles when an item is renamed
+    /// @param p_old_name the old name
+    /// @param p_new_name the new name
+    virtual bool _handle_item_renamed(const String& p_old_name, const String& p_new_name) { return false; }
+
+    /// Handles the removal of the item
+    /// @param p_item the tree item to be removed
+    virtual void _handle_remove(TreeItem* p_item) { }
+
+    /// Handles button click in the tree
+    /// @param p_item the tree item
+    /// @param p_column the tree column
+    /// @param p_id the button id
+    /// @param p_mouse_button the mouse button pressed
+    virtual void _handle_button_clicked(TreeItem* p_item, int p_column, int p_id, int p_mouse_button) { }
+
+    /// Generates a drag-and-drop dictionary data bucket
+    /// @param p_position the position where the drag started
+    /// @return data to be used for the draggable item, returning an empty Dictionary cancels the drag
+    virtual Dictionary _handle_drag_data(const Vector2& p_position) { return {}; }
+
+    /// Default constructor
+    OrchestratorScriptComponentPanel() = default;
+
+public:
+    //~ Begin Control Interface
+    void _gui_input(const Ref<InputEvent>& p_event) override;
+    //~ End Control Interface
+
+    /// Updates this control, should be called by the script view
+    virtual void update();
+
+    /// Find the item by name and edit it (if it exists)
+    /// @param p_item_name
+    void find_and_edit(const String& p_item_name);
+
+    /// Godot's notification callback
+    /// @param p_what the notification type
+    void _notification(int p_what);
+
+    /// Constructs a component panel
+    /// @param p_title the panel title
+    /// @param p_script the script
+    OrchestratorScriptComponentPanel(const String& p_title, const Ref<OScript>& p_script);
+};
+
+#endif  // ORCHESTRATOR_SCRIPT_COMPONENT_PANEL_H

--- a/src/editor/component_panels/functions_panel.cpp
+++ b/src/editor/component_panels/functions_panel.cpp
@@ -1,0 +1,219 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "editor/component_panels/functions_panel.h"
+
+#include "common/callable_lambda.h"
+#include "common/scene_utils.h"
+#include "editor/script_connections.h"
+#include "editor/script_view.h"
+#include "plugin/plugin.h"
+#include "script/script.h"
+
+#include <godot_cpp/classes/button.hpp>
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/h_box_container.hpp>
+#include <godot_cpp/classes/popup_menu.hpp>
+#include <godot_cpp/classes/tree.hpp>
+
+void OrchestratorScriptFunctionsComponentPanel::_show_function_graph(TreeItem* p_item)
+{
+    // Function name and graph names are synonymous
+    const String function_name = p_item->get_text(0);
+    emit_signal("show_graph_requested", function_name);
+    emit_signal("focus_node_requested", function_name, _script->get_function_node_id(function_name));
+    _tree->deselect_all();
+}
+
+PackedStringArray OrchestratorScriptFunctionsComponentPanel::_get_existing_names() const
+{
+    return _script->get_function_names();
+}
+
+String OrchestratorScriptFunctionsComponentPanel::_get_tooltip_text() const
+{
+    return "A function graph allows the encapsulation of functionality for re-use. Function graphs have "
+           "a single input with an optional output node. Function graphs have a single execution pin "
+           "with multiple input data pins and the result node may return a maximum of one data value to "
+           "the caller.\n\n"
+           "Functions can be called by selecting the action in the action menu or by dragging the "
+           "function from this component view onto the graph area.";
+}
+
+String OrchestratorScriptFunctionsComponentPanel::_get_remove_confirm_text(TreeItem* p_item) const
+{
+    return "Removing a function removes all nodes that participate in the function and any nodes\n"
+           "that call that function from the event graphs.";
+}
+
+bool OrchestratorScriptFunctionsComponentPanel::_populate_context_menu(TreeItem* p_item)
+{
+    _context_menu->add_item("Open in Graph", CM_OPEN_FUNCTION_GRAPH);
+    _context_menu->add_icon_item(SceneUtils::get_editor_icon("Rename"), "Rename", CM_RENAME_FUNCTION);
+    _context_menu->add_icon_item(SceneUtils::get_editor_icon("Remove"), "Remove", CM_REMOVE_FUNCTION);
+    return true;
+}
+
+void OrchestratorScriptFunctionsComponentPanel::_handle_context_menu(int p_id)
+{
+    switch (p_id)
+    {
+        case CM_OPEN_FUNCTION_GRAPH:
+            _show_function_graph(_tree->get_selected());
+            break;
+        case CM_RENAME_FUNCTION:
+            _tree->edit_selected(true);
+            break;
+        case CM_REMOVE_FUNCTION:
+            _confirm_removal(_tree->get_selected());
+            break;
+    }
+}
+
+bool OrchestratorScriptFunctionsComponentPanel::_handle_add_new_item(const String& p_name)
+{
+    return _view->_create_new_function(p_name).is_valid();
+}
+
+void OrchestratorScriptFunctionsComponentPanel::_handle_item_selected()
+{
+    const TreeItem* item = _tree->get_selected();
+    if (item)
+    {
+        const Ref<OScriptFunction> function = _script->find_function(StringName(item->get_text(0)));
+        if (function.is_valid())
+        {
+            const Ref<OScriptNode> node = function->get_owning_node();
+            if (node.is_valid())
+                OrchestratorPlugin::get_singleton()->get_editor_interface()->edit_resource(node);
+        }
+    }
+}
+
+void OrchestratorScriptFunctionsComponentPanel::_handle_item_activated(TreeItem* p_item)
+{
+    _show_function_graph(p_item);
+}
+
+bool OrchestratorScriptFunctionsComponentPanel::_handle_item_renamed(const String& p_old_name, const String& p_new_name)
+{
+    if (_get_existing_names().has(p_new_name))
+    {
+        _show_notification("A function with the name '" + p_new_name + "' already exists.");
+        return false;
+    }
+
+    _script->rename_function(p_old_name, p_new_name);
+    emit_signal("graph_renamed", p_old_name, p_new_name);
+    return true;
+}
+
+void OrchestratorScriptFunctionsComponentPanel::_handle_remove(TreeItem* p_item)
+{
+    // Function name and graph names are synonymous
+    const String function_name = p_item->get_text(0);
+    emit_signal("close_graph_requested", function_name);
+
+    _script->remove_function(function_name);
+}
+
+void OrchestratorScriptFunctionsComponentPanel::_handle_button_clicked(TreeItem* p_item, int p_column, int p_id,
+                                                                    int p_mouse_button)
+{
+    const Vector<Node*> nodes = SceneUtils::find_all_nodes_for_script_in_edited_scene(_script);
+
+    OrchestratorScriptConnectionsDialog* dialog = memnew(OrchestratorScriptConnectionsDialog);
+    add_child(dialog);
+    dialog->popup_connections(p_item->get_text(0), nodes);
+}
+
+Dictionary OrchestratorScriptFunctionsComponentPanel::_handle_drag_data(const Vector2& p_position)
+{
+    Dictionary data;
+
+    TreeItem* selected = _tree->get_selected();
+    if (selected)
+    {
+        data["type"] = "function";
+        data["functions"] = Array::make(selected->get_text(0));
+    }
+    return data;
+}
+
+void OrchestratorScriptFunctionsComponentPanel::update()
+{
+    _clear_tree();
+
+    const Vector<Node*> script_nodes = SceneUtils::find_all_nodes_for_script_in_edited_scene(_script);
+    const String base_type = _script->get_instance_base_type();
+
+    for (const Ref<OScriptGraph>& graph : _script->get_graphs())
+    {
+        if (!(graph->get_flags().has_flag(OScriptGraph::GraphFlags::GF_FUNCTION)))
+            continue;
+
+        TreeItem* item = _tree->get_root()->create_child();
+        item->set_text(0, graph->get_graph_name());
+        item->set_meta("__name", graph->get_graph_name()); // Used for renames
+        item->set_icon(0, SceneUtils::get_editor_icon("MemberMethod"));
+
+        if (SceneUtils::has_any_signals_connected_to_function(graph->get_graph_name(), base_type, script_nodes))
+            item->add_button(0, SceneUtils::get_editor_icon("Slot"));
+    }
+
+    if (_tree->get_root()->get_child_count() == 0)
+    {
+        TreeItem* item = _tree->get_root()->create_child();
+        item->set_text(0, "No functions defined");
+        item->set_selectable(0, false);
+        return;
+    }
+
+    OrchestratorScriptComponentPanel::update();
+}
+
+void OrchestratorScriptFunctionsComponentPanel::_notification(int p_what)
+{
+    // Godot does not dispatch to parent (shrugs)
+    OrchestratorScriptComponentPanel::_notification(p_what);
+
+    if (p_what == NOTIFICATION_READY)
+    {
+        HBoxContainer* container = _get_panel_hbox();
+
+        Button* override_button = memnew(Button);
+        override_button->set_focus_mode(FOCUS_NONE);
+        override_button->set_button_icon(SceneUtils::get_editor_icon("Override"));
+        override_button->set_tooltip_text("Override a Godot virtual function");
+        container->add_child(override_button);
+
+        override_button->connect("pressed", callable_mp_lambda(this, [=] { emit_signal("override_function_requested"); }));
+    }
+}
+
+void OrchestratorScriptFunctionsComponentPanel::_bind_methods()
+{
+    ADD_SIGNAL(MethodInfo("show_graph_requested", PropertyInfo(Variant::STRING, "graph_name")));
+    ADD_SIGNAL(MethodInfo("close_graph_requested", PropertyInfo(Variant::STRING, "graph_name")));
+    ADD_SIGNAL(MethodInfo("graph_renamed", PropertyInfo(Variant::STRING, "old_name"), PropertyInfo(Variant::STRING, "new_name")));
+    ADD_SIGNAL(MethodInfo("focus_node_requested", PropertyInfo(Variant::STRING, "graph_name"), PropertyInfo(Variant::INT, "node_id")));
+    ADD_SIGNAL(MethodInfo("override_function_requested"));
+}
+
+OrchestratorScriptFunctionsComponentPanel::OrchestratorScriptFunctionsComponentPanel(const Ref<OScript>& p_script, OrchestratorScriptView* p_view)
+    : OrchestratorScriptComponentPanel("Functions", p_script), _view(p_view)
+{
+}

--- a/src/editor/component_panels/functions_panel.h
+++ b/src/editor/component_panels/functions_panel.h
@@ -1,0 +1,77 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef ORCHESTRATOR_SCRIPT_FUNCTIONS_COMPONENT_PANEL_H
+#define ORCHESTRATOR_SCRIPT_FUNCTIONS_COMPONENT_PANEL_H
+
+#include "editor/component_panels/component_panel.h"
+
+class OrchestratorScriptView;
+
+class OrchestratorScriptFunctionsComponentPanel : public OrchestratorScriptComponentPanel
+{
+    GDCLASS(OrchestratorScriptFunctionsComponentPanel, OrchestratorScriptComponentPanel);
+    static void _bind_methods();
+
+    enum ContextMenuIds
+    {
+        CM_OPEN_FUNCTION_GRAPH,
+        CM_RENAME_FUNCTION,
+        CM_REMOVE_FUNCTION
+    };
+
+    OrchestratorScriptView* _view;
+
+protected:
+    //~ Begin OrchestratorScriptComponentPanel Interface
+    String _get_unique_name_prefix() const override { return "NewFunction"; }
+    PackedStringArray _get_existing_names() const override;
+    String _get_tooltip_text() const override;
+    String _get_remove_confirm_text(TreeItem* p_item) const override;
+    String _get_item_name() const override { return "Function"; }
+    bool _populate_context_menu(TreeItem* p_item) override;
+    void _handle_context_menu(int p_id) override;
+    bool _handle_add_new_item(const String& p_name) override;
+    void _handle_item_selected() override;
+    void _handle_item_activated(TreeItem* p_item) override;
+    bool _handle_item_renamed(const String& p_old_name, const String& p_new_name) override;
+    void _handle_remove(TreeItem* p_item) override;
+    void _handle_button_clicked(TreeItem* p_item, int p_column, int p_id, int p_mouse_button) override;
+    Dictionary _handle_drag_data(const Vector2& p_position) override;
+    //~ End OrchestratorScriptComponentPanel Interface
+
+    //~ Begin Signal handlers
+    void _show_function_graph(TreeItem* p_item);
+    //~ End Signal handlers
+
+    /// Default constructor
+    OrchestratorScriptFunctionsComponentPanel() = default;
+
+public:
+    //~ Begin OrchestratorScriptViewSection Interface
+    void update() override;
+    //~ End OrchestratorScriptViewSection Interface
+
+    /// Godot's notification callback
+    /// @param p_what the notification type
+    void _notification(int p_what);
+
+    /// Construct the function component panel
+    /// @param p_script the script
+    explicit OrchestratorScriptFunctionsComponentPanel(const Ref<OScript>& p_script, OrchestratorScriptView* p_view);
+};
+
+#endif // ORCHESTRATOR_SCRIPT_FUNCTIONS_COMPONENT_PANEL_H

--- a/src/editor/component_panels/graphs_panel.cpp
+++ b/src/editor/component_panels/graphs_panel.cpp
@@ -1,0 +1,231 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "editor/component_panels/graphs_panel.h"
+
+#include "common/scene_utils.h"
+#include "editor/script_connections.h"
+
+#include <godot_cpp/classes/popup_menu.hpp>
+#include <godot_cpp/classes/tree.hpp>
+
+void OrchestratorScriptGraphsComponentPanel::_show_graph_item(TreeItem* p_item)
+{
+    const String graph_name = p_item->get_text(0);
+
+    // Graph
+    emit_signal("show_graph_requested", graph_name);
+    _tree->deselect_all();
+}
+
+void OrchestratorScriptGraphsComponentPanel::_focus_graph_function(TreeItem* p_item)
+{
+    const String graph_name = p_item->get_parent()->get_text(0);
+    const int node_id = _script->get_function_node_id(p_item->get_text(0));
+
+    // Specific event node
+    emit_signal("focus_node_requested", graph_name, node_id);
+    _tree->deselect_all();
+}
+
+void OrchestratorScriptGraphsComponentPanel::_remove_graph(TreeItem* p_item)
+{
+    const String graph_name = p_item->get_text(0);
+    emit_signal("close_graph_requested", graph_name);
+
+    _script->remove_graph(graph_name);
+}
+
+void OrchestratorScriptGraphsComponentPanel::_remove_graph_function(TreeItem* p_item)
+{
+    const String function_name = p_item->get_text(0);
+
+    _script->remove_function(function_name);
+    update();
+}
+
+PackedStringArray OrchestratorScriptGraphsComponentPanel::_get_existing_names() const
+{
+    PackedStringArray result;
+    for (const Ref<OScriptGraph>& graph : _script->get_graphs())
+        result.push_back(graph->get_graph_name());
+    return result;
+}
+
+String OrchestratorScriptGraphsComponentPanel::_get_tooltip_text() const
+{
+    return "A graph allows you to place many types of nodes to create various behaviors. "
+           "Event graphs are flexible and can control multiple event nodes that start execution, "
+           "nodes that may take time, react to signals, or call functions and macro nodes.\n\n"
+           "While there is always one event graph called \"EventGraph\", you can create new "
+           "event graphs to better help organize event logic.";
+}
+
+String OrchestratorScriptGraphsComponentPanel::_get_remove_confirm_text(TreeItem* p_item) const
+{
+    // Only confirm graphs, not event functions
+    if (p_item->get_parent() == _tree->get_root())
+        return "Removing a graph removes all nodes within the graph.";
+
+    return OrchestratorScriptComponentPanel::_get_remove_confirm_text(p_item);
+}
+
+bool OrchestratorScriptGraphsComponentPanel::_populate_context_menu(TreeItem* p_item)
+{
+    if (p_item->get_parent() == _tree->get_root())
+    {
+        // Graph
+        Ref<OScriptGraph> graph = _script->get_graph(p_item->get_text(0));
+        bool rename_disabled = !graph->get_flags().has_flag(OScriptGraph::GraphFlags::GF_RENAMABLE);
+        bool delete_disabled = !graph->get_flags().has_flag(OScriptGraph::GraphFlags::GF_DELETABLE);
+        _context_menu->add_item("Open Graph", CM_OPEN_GRAPH);
+        _context_menu->add_icon_item(SceneUtils::get_editor_icon("Rename"), "Rename", CM_RENAME_GRAPH);
+        _context_menu->set_item_disabled(_context_menu->get_item_count() - 1, rename_disabled);
+        _context_menu->add_icon_item(SceneUtils::get_editor_icon("Remove"), "Remove", CM_REMOVE_GRAPH);
+        _context_menu->set_item_disabled(_context_menu->get_item_count() - 1, delete_disabled);
+    }
+    else
+    {
+        // Graph Functions
+        _context_menu->add_item("Focus", CM_FOCUS_FUNCTION);
+        _context_menu->add_icon_item(SceneUtils::get_editor_icon("Remove"), "Remove", CM_REMOVE_FUNCTION);
+    }
+    return true;
+}
+
+void OrchestratorScriptGraphsComponentPanel::_handle_context_menu(int p_id)
+{
+    switch (p_id)
+    {
+        case CM_OPEN_GRAPH:
+            _show_graph_item(_tree->get_selected());
+            break;
+        case CM_RENAME_GRAPH:
+            _tree->edit_selected(true);
+            break;
+        case CM_REMOVE_GRAPH:
+            _confirm_removal(_tree->get_selected());
+            break;
+        case CM_FOCUS_FUNCTION:
+            _focus_graph_function(_tree->get_selected());
+            break;
+        case CM_REMOVE_FUNCTION:
+            _remove_graph_function(_tree->get_selected());
+            break;
+    }
+}
+
+bool OrchestratorScriptGraphsComponentPanel::_handle_add_new_item(const String& p_name)
+{
+    // Add the new graph and update the components display
+    return _script->create_graph(p_name, OScriptGraph::GF_EVENT | OScriptGraph::GF_DEFAULT).is_valid();
+}
+
+void OrchestratorScriptGraphsComponentPanel::_handle_item_activated(TreeItem* p_item)
+{
+    if (p_item->get_parent() == _tree->get_root())
+        _show_graph_item(p_item);
+    else
+        _focus_graph_function(p_item);
+}
+
+bool OrchestratorScriptGraphsComponentPanel::_handle_item_renamed(const String& p_old_name, const String& p_new_name)
+{
+    if (_get_existing_names().has(p_new_name))
+    {
+        _show_notification("A graph with the name '" + p_new_name + "' already exists.");
+        return false;
+    }
+
+    _script->rename_graph(p_old_name, p_new_name);
+    emit_signal("graph_renamed", p_old_name, p_new_name);
+    return true;
+}
+
+void OrchestratorScriptGraphsComponentPanel::_handle_remove(TreeItem* p_item)
+{
+    if (p_item->get_parent() == _tree->get_root())
+        _remove_graph(p_item);
+}
+
+void OrchestratorScriptGraphsComponentPanel::_handle_button_clicked(TreeItem* p_item, int p_column, int p_id,
+                                                                 int p_mouse_button)
+{
+    const Vector<Node*> nodes = SceneUtils::find_all_nodes_for_script_in_edited_scene(_script);
+
+    OrchestratorScriptConnectionsDialog* dialog = memnew(OrchestratorScriptConnectionsDialog);
+    add_child(dialog);
+    dialog->popup_connections(p_item->get_text(0), nodes);
+}
+
+void OrchestratorScriptGraphsComponentPanel::update()
+{
+    _clear_tree();
+
+    Vector<Ref<OScriptGraph>> graphs = _script->get_graphs();
+    if (graphs.is_empty())
+    {
+        TreeItem* item = _tree->get_root()->create_child();
+        item->set_text(0, "No graphs defined");
+        item->set_selectable(0, false);
+        return;
+    }
+
+    const Vector<Node*> script_nodes = SceneUtils::find_all_nodes_for_script_in_edited_scene(_script);
+    const String base_type = _script->get_instance_base_type();
+
+    const PackedStringArray functions = _script->get_function_names();
+    for (const Ref<OScriptGraph>& graph : graphs)
+    {
+        if (!(graph->get_flags().has_flag(OScriptGraph::GraphFlags::GF_EVENT)))
+            continue;
+
+        TreeItem* item = _tree->get_root()->create_child();
+        item->set_text(0, graph->get_graph_name());
+        item->set_meta("__name", graph->get_graph_name()); // Used for renames
+        item->set_icon(0, SceneUtils::get_editor_icon("ClassList"));
+
+        TypedArray<int> nodes = graph->get_nodes();
+        for (const String& function_name : functions)
+        {
+            int function_id = _script->get_function_node_id(function_name);
+            if (nodes.has(function_id))
+            {
+                TreeItem* func = item->create_child();
+                func->set_text(0, function_name);
+                func->set_icon(0, SceneUtils::get_editor_icon("PlayStart"));
+
+                if (SceneUtils::has_any_signals_connected_to_function(function_name, base_type, script_nodes))
+                    func->add_button(0, SceneUtils::get_editor_icon("Slot"));
+            }
+        }
+    }
+
+    OrchestratorScriptComponentPanel::update();
+}
+
+void OrchestratorScriptGraphsComponentPanel::_bind_methods()
+{
+    ADD_SIGNAL(MethodInfo("show_graph_requested", PropertyInfo(Variant::STRING, "graph_name")));
+    ADD_SIGNAL(MethodInfo("close_graph_requested", PropertyInfo(Variant::STRING, "graph_name")));
+    ADD_SIGNAL(MethodInfo("graph_renamed", PropertyInfo(Variant::STRING, "old_name"), PropertyInfo(Variant::STRING, "new_name")));
+    ADD_SIGNAL(MethodInfo("focus_node_requested", PropertyInfo(Variant::STRING, "graph_name"), PropertyInfo(Variant::INT, "node_id")));
+}
+
+OrchestratorScriptGraphsComponentPanel::OrchestratorScriptGraphsComponentPanel(const Ref<OScript>& p_script)
+    : OrchestratorScriptComponentPanel("Graphs", p_script)
+{
+}

--- a/src/editor/component_panels/graphs_panel.h
+++ b/src/editor/component_panels/graphs_panel.h
@@ -1,0 +1,82 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef ORCHESTRATOR_SCRIPT_GRAPHS_COMPONENT_PANEL_H
+#define ORCHESTRATOR_SCRIPT_GRAPHS_COMPONENT_PANEL_H
+
+#include "editor/component_panels/component_panel.h"
+
+class OrchestratorScriptGraphsComponentPanel : public OrchestratorScriptComponentPanel
+{
+    GDCLASS(OrchestratorScriptGraphsComponentPanel, OrchestratorScriptComponentPanel);
+    static void _bind_methods();
+
+    enum ContextMenuIds
+    {
+        CM_OPEN_GRAPH,
+        CM_RENAME_GRAPH,
+        CM_REMOVE_GRAPH,
+        CM_FOCUS_FUNCTION,
+        CM_REMOVE_FUNCTION
+    };
+
+protected:
+    //~ Begin OrchestratorScriptComponentPanel Interface
+    String _get_unique_name_prefix() const override { return "NewEventGraph"; }
+    PackedStringArray _get_existing_names() const override;
+    String _get_tooltip_text() const override;
+    String _get_remove_confirm_text(TreeItem* p_item) const override;
+    String _get_item_name() const override { return "EventGraph"; }
+    bool _populate_context_menu(TreeItem* p_item) override;
+    void _handle_context_menu(int p_id) override;
+    bool _handle_add_new_item(const String& p_name) override;
+    void _handle_item_activated(TreeItem* p_item) override;
+    bool _handle_item_renamed(const String& p_old_name, const String& p_new_name) override;
+    void _handle_remove(TreeItem* p_item) override;
+    void _handle_button_clicked(TreeItem* p_item, int p_column, int p_id, int p_mouse_button) override;
+    //~ End OrchestratorScriptComponentPanel Interface
+
+    /// Notifies the script view to show the specified graph associated with the tree item
+    /// @param p_item the graph tree item, should not be null
+    void _show_graph_item(TreeItem* p_item);
+
+    /// Notifies the script view to focus a specific event node in the graph.
+    /// @param p_item the graph event item, should not be null
+    void _focus_graph_function(TreeItem* p_item);
+
+    /// Notifies the script view that a graph has been removed.
+    /// This is useful to close any views that pertain to the graph.
+    /// @param p_item the graph item, should not be null
+    void _remove_graph(TreeItem* p_item);
+
+    /// Notifies the script view that a graph function was removed.
+    /// @param p_item the graph function item, should not be null
+    void _remove_graph_function(TreeItem* p_item);
+
+    /// Default constructor
+    OrchestratorScriptGraphsComponentPanel() = default;
+
+public:
+    //~ Begin OrchestratorScriptViewSection Interface
+    void update() override;
+    //~ End OrchestratorScriptViewSection Interface
+
+    /// Constructs the graphs component panel
+    /// @param p_script the script
+    explicit OrchestratorScriptGraphsComponentPanel(const Ref<OScript>& p_script);
+};
+
+#endif // ORCHESTRATOR_SCRIPT_GRAPHS_COMPONENT_PANEL_H

--- a/src/editor/component_panels/macros_panel.cpp
+++ b/src/editor/component_panels/macros_panel.cpp
@@ -1,0 +1,67 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "editor/component_panels/macros_panel.h"
+
+#include <godot_cpp/classes/button.hpp>
+#include <godot_cpp/classes/h_box_container.hpp>
+#include <godot_cpp/classes/tree.hpp>
+
+String OrchestratorScriptMacrosComponentPanel::_get_tooltip_text() const
+{
+    return "A macro graph allows for the encapsulation of functionality for re-use. Macros have both a "
+           "singular input and output node, but these nodes can have as many input or output data "
+           "values needed for logic. Macros can contain nodes that take time, such as delays, but are "
+           "not permitted to contain event nodes, such as a node that reacts to '_ready'.\n\n"
+           "This feature is currently disabled and will be available in a future release.";
+}
+
+void OrchestratorScriptMacrosComponentPanel::update()
+{
+    if (_tree->get_root()->get_child_count() == 0)
+    {
+        TreeItem* item = _tree->get_root()->create_child();
+        item->set_text(0, "No macros defined");
+        item->set_selectable(0, false);
+        return;
+    }
+
+    OrchestratorScriptComponentPanel::update();
+}
+
+void OrchestratorScriptMacrosComponentPanel::_notification(int p_what)
+{
+    // Godot does not dispatch to parent (shrugs)
+    OrchestratorScriptComponentPanel::_notification(p_what);
+
+    if (p_what == NOTIFICATION_READY)
+    {
+        HBoxContainer* container = _get_panel_hbox();
+
+        Button* button = Object::cast_to<Button>(container->get_child(-1));
+        if (button)
+            button->set_disabled(true);
+    }
+}
+
+void OrchestratorScriptMacrosComponentPanel::_bind_methods()
+{
+}
+
+OrchestratorScriptMacrosComponentPanel::OrchestratorScriptMacrosComponentPanel(const Ref<OScript>& p_script)
+    : OrchestratorScriptComponentPanel("Macros", p_script)
+{
+}

--- a/src/editor/component_panels/macros_panel.h
+++ b/src/editor/component_panels/macros_panel.h
@@ -1,0 +1,51 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef ORCHESTRATOR_SCRIPT_MACROS_COMPONENT_PANEL_H
+#define ORCHESTRATOR_SCRIPT_MACROS_COMPONENT_PANEL_H
+
+#include "editor/component_panels/component_panel.h"
+
+class OrchestratorScriptMacrosComponentPanel : public OrchestratorScriptComponentPanel
+{
+    GDCLASS(OrchestratorScriptMacrosComponentPanel, OrchestratorScriptComponentPanel);
+    static void _bind_methods();
+
+protected:
+    //~ Begin OrchestratorScriptComponentPanel Interface
+    String _get_unique_name_prefix() const override { return "NewMacro"; }
+    String _get_tooltip_text() const override;
+    String _get_item_name() const override { return "Macro"; }
+    //~ End OrchestratorScriptComponentPanel Interface
+
+    /// Default constructor
+    OrchestratorScriptMacrosComponentPanel() = default;
+
+public:
+    //~ Begin OrchestratorScriptViewSection Interface
+    void update() override;
+    //~ End OrchestratorScriptViewSection Interface
+
+    /// Godot's notification callback
+    /// @param p_what the notification type
+    void _notification(int p_what);
+
+    /// Construct the function component panel
+    /// @param p_script the script
+    explicit OrchestratorScriptMacrosComponentPanel(const Ref<OScript>& p_script);
+};
+
+#endif // ORCHESTRATOR_SCRIPT_MACROS_COMPONENT_PANEL_H

--- a/src/editor/component_panels/signals_panel.cpp
+++ b/src/editor/component_panels/signals_panel.cpp
@@ -1,0 +1,152 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "editor/component_panels/signals_panel.h"
+
+#include "common/scene_utils.h"
+#include "plugin/plugin.h"
+
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/popup_menu.hpp>
+#include <godot_cpp/classes/tree.hpp>
+
+PackedStringArray OrchestratorScriptSignalsComponentPanel::_get_existing_names() const
+{
+    return _script->get_custom_signal_names();
+}
+
+String OrchestratorScriptSignalsComponentPanel::_get_tooltip_text() const
+{
+    return "A signal is used to send a notification synchronously to any number of observers that have "
+           "connected to the defined signal on the orchestration. Signals allow for a variable number "
+           "of arguments to be passed to the observer.\n\n"
+           "Selecting a signal in the component view displays the signal details in the inspector.";
+}
+
+String OrchestratorScriptSignalsComponentPanel::_get_remove_confirm_text(TreeItem* p_item) const
+{
+    return "Removing a signal will remove all nodes that emit the signal.";
+}
+
+bool OrchestratorScriptSignalsComponentPanel::_populate_context_menu(TreeItem* p_item)
+{
+    _context_menu->add_icon_item(SceneUtils::get_editor_icon("Rename"), "Rename", CM_RENAME_SIGNAL);
+    _context_menu->add_icon_item(SceneUtils::get_editor_icon("Remove"), "Remove", CM_REMOVE_SIGNAL);
+    return true;
+}
+
+void OrchestratorScriptSignalsComponentPanel::_handle_context_menu(int p_id)
+{
+    switch (p_id)
+    {
+        case CM_RENAME_SIGNAL:
+            _tree->edit_selected(true);
+            break;
+        case CM_REMOVE_SIGNAL:
+            _confirm_removal(_tree->get_selected());
+            break;
+    }
+}
+
+bool OrchestratorScriptSignalsComponentPanel::_handle_add_new_item(const String& p_name)
+{
+    // Add the new signal and update the components display
+    return _script->create_custom_signal(p_name).is_valid();
+}
+
+void OrchestratorScriptSignalsComponentPanel::_handle_item_selected()
+{
+    TreeItem* item = _tree->get_selected();
+
+    Ref<OScriptSignal> signal = _script->get_custom_signal(item->get_text(0));
+    OrchestratorPlugin::get_singleton()->get_editor_interface()->edit_resource(signal);
+}
+
+void OrchestratorScriptSignalsComponentPanel::_handle_item_activated(TreeItem* p_item)
+{
+    Ref<OScriptSignal> signal = _script->get_custom_signal(p_item->get_text(0));
+    OrchestratorPlugin::get_singleton()->get_editor_interface()->edit_resource(signal);
+}
+
+bool OrchestratorScriptSignalsComponentPanel::_handle_item_renamed(const String& p_old_name, const String& p_new_name)
+{
+    if (_get_existing_names().has(p_new_name))
+    {
+        _show_notification("A signal with the name '" + p_new_name + "' already exists.");
+        return false;
+    }
+
+    _script->rename_custom_user_signal(p_old_name, p_new_name);
+    return true;
+}
+
+void OrchestratorScriptSignalsComponentPanel::_handle_remove(TreeItem* p_item)
+{
+    const String signal_name = p_item->get_text(0);
+    _script->remove_custom_signal(signal_name);
+}
+
+Dictionary OrchestratorScriptSignalsComponentPanel::_handle_drag_data(const Vector2& p_position)
+{
+    Dictionary data;
+
+    TreeItem* selected = _tree->get_selected();
+    if (selected)
+    {
+        data["type"] = "signal";
+        data["signals"] = Array::make(selected->get_text(0));
+    }
+    return data;
+}
+
+void OrchestratorScriptSignalsComponentPanel::update()
+{
+    _clear_tree();
+
+    PackedStringArray signal_names = _script->get_custom_signal_names();
+    if (!signal_names.is_empty())
+    {
+        signal_names.sort();
+        for (const String& signal_name : signal_names)
+        {
+            Ref<OScriptSignal> signal = _script->get_custom_signal(signal_name);
+
+            TreeItem* item = _tree->get_root()->create_child();
+            item->set_text(0, signal_name);
+            item->set_meta("__name", signal_name);
+            item->set_icon(0, SceneUtils::get_editor_icon("MemberSignal"));
+        }
+    }
+
+    if (_tree->get_root()->get_child_count() == 0)
+    {
+        TreeItem* item = _tree->get_root()->create_child();
+        item->set_text(0, "No signals defined");
+        item->set_selectable(0, false);
+        return;
+    }
+
+    OrchestratorScriptComponentPanel::update();
+}
+
+void OrchestratorScriptSignalsComponentPanel::_bind_methods()
+{
+}
+
+OrchestratorScriptSignalsComponentPanel::OrchestratorScriptSignalsComponentPanel(const Ref<OScript>& p_script)
+    : OrchestratorScriptComponentPanel("Signals", p_script)
+{
+}

--- a/src/editor/component_panels/signals_panel.h
+++ b/src/editor/component_panels/signals_panel.h
@@ -1,0 +1,63 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef ORCHESTRATOR_SCRIPT_SIGNALS_COMPONENT_PANEL_H
+#define ORCHESTRATOR_SCRIPT_SIGNALS_COMPONENT_PANEL_H
+
+#include "editor/component_panels/component_panel.h"
+
+class OrchestratorScriptSignalsComponentPanel : public OrchestratorScriptComponentPanel
+{
+    GDCLASS(OrchestratorScriptSignalsComponentPanel, OrchestratorScriptComponentPanel);
+    static void _bind_methods();
+
+    enum ContextMenuIds
+    {
+        CM_RENAME_SIGNAL,
+        CM_REMOVE_SIGNAL
+    };
+
+protected:
+    //~ Begin OrchestratorScriptViewSection Interface
+    String _get_unique_name_prefix() const override { return "NewSignal"; }
+    PackedStringArray _get_existing_names() const override;
+    String _get_tooltip_text() const override;
+    String _get_remove_confirm_text(TreeItem* p_item) const override;
+    String _get_item_name() const override { return "Signal"; }
+    bool _populate_context_menu(TreeItem* p_item) override;
+    void _handle_context_menu(int p_id) override;
+    bool _handle_add_new_item(const String& p_name) override;
+    void _handle_item_selected() override;
+    void _handle_item_activated(TreeItem* p_item) override;
+    bool _handle_item_renamed(const String& p_old_name, const String& p_new_name) override;
+    void _handle_remove(TreeItem* p_item) override;
+    Dictionary _handle_drag_data(const Vector2& p_position) override;
+    //~ End OrchestratorScriptViewSection Interface
+
+    /// Default constructor
+    OrchestratorScriptSignalsComponentPanel() = default;
+
+public:
+    //~ Begin OrchestratorScriptViewSection Interface
+    void update() override;
+    //~ End OrchestratorScriptViewSection Interface
+
+    /// Construct a signals component panel
+    /// @param p_script the script
+    explicit OrchestratorScriptSignalsComponentPanel(const Ref<OScript>& p_script);
+};
+
+#endif // ORCHESTRATOR_SCRIPT_SIGNALS_COMPONENT_PANEL_H

--- a/src/editor/component_panels/variables_panel.cpp
+++ b/src/editor/component_panels/variables_panel.cpp
@@ -1,0 +1,288 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "editor/component_panels/variables_panel.h"
+
+#include "common/callable_lambda.h"
+#include "common/scene_utils.h"
+#include "plugin/inspector_plugin_variable.h"
+#include "plugin/plugin.h"
+
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/popup_menu.hpp>
+#include <godot_cpp/classes/tree.hpp>
+
+void OrchestratorScriptVariablesComponentPanel::_create_item(TreeItem* p_parent, const Ref<OScriptVariable>& p_variable)
+{
+    TreeItem* category = nullptr;
+    for (TreeItem* child = p_parent->get_first_child(); child; child = child->get_next())
+    {
+        if (child->get_text(0).match(p_variable->get_category()))
+        {
+            category = child;
+            break;
+        }
+    }
+
+    if (p_variable->is_grouped_by_category())
+    {
+        if (!category)
+        {
+            category = p_parent->create_child();
+            category->set_text(0, p_variable->get_category());
+            category->set_selectable(0, false);
+        }
+    }
+    else
+        category = p_parent;
+
+    TreeItem* item = category->create_child();
+    item->set_text(0, p_variable->get_variable_name());
+    item->set_icon(0, SceneUtils::get_editor_icon("MemberProperty"));
+    item->set_meta("__name", p_variable->get_variable_name());
+
+    if (p_variable->is_exported() && p_variable->get_variable_name().begins_with("_"))
+    {
+        int32_t index = item->get_button_count(0);
+        item->add_button(0, SceneUtils::get_editor_icon("NodeWarning"), 1);
+        item->set_button_tooltip_text(0, index, "Variable is exported but defined as private using underscore prefix.");
+        item->set_button_disabled(0, index, true);
+    }
+
+    item->add_button(0, SceneUtils::get_editor_icon(p_variable->get_variable_type_name()), 2);
+
+    if (!p_variable->get_description().is_empty())
+    {
+        const String tooltip = p_variable->get_variable_name() + "\n\n" + p_variable->get_description();
+        item->set_tooltip_text(0, SceneUtils::create_wrapped_tooltip_text(tooltip));
+    }
+
+    if (p_variable->is_exported())
+    {
+        int32_t index = item->get_button_count(0);
+        item->add_button(0, SceneUtils::get_editor_icon("GuiVisibilityVisible"), 3);
+        item->set_button_tooltip_text(0, index, "Variable is visible outside the orchestration.");
+        item->set_button_disabled(0, index, false);
+    }
+    else
+    {
+        String tooltip = "Variable is private.";
+        if (!p_variable->is_exportable())
+            tooltip += "\nType cannot be exported.";
+
+        int32_t index = item->get_button_count(0);
+        item->add_button(0, SceneUtils::get_editor_icon("GuiVisibilityHidden"), 3);
+        item->set_button_tooltip_text(0, index, tooltip);
+        item->set_button_disabled(0, index, !p_variable->is_exportable());
+    }
+}
+
+PackedStringArray OrchestratorScriptVariablesComponentPanel::_get_existing_names() const
+{
+    return _script->get_variable_names();
+}
+
+String OrchestratorScriptVariablesComponentPanel::_get_tooltip_text() const
+{
+    return "A variable represents some data that will be stored and managed by the orchestration.\n\n"
+           "Drag a variable from the component view onto the graph area to select whether to create "
+           "a get/set node or use the action menu to find the get/set option for the variable.\n\n"
+           "Selecting a variable in the component view displays the variable details in the inspector.";
+}
+
+String OrchestratorScriptVariablesComponentPanel::_get_remove_confirm_text(TreeItem* p_item) const
+{
+    return "Removing a variable will remove all nodes that get or set the variable.";
+}
+
+bool OrchestratorScriptVariablesComponentPanel::_populate_context_menu(TreeItem* p_item)
+{
+    _context_menu->add_icon_item(SceneUtils::get_editor_icon("Rename"), "Rename", CM_RENAME_VARIABLE);
+    _context_menu->add_icon_item(SceneUtils::get_editor_icon("Remove"), "Remove", CM_REMOVE_VARIABLE);
+    return true;
+}
+
+void OrchestratorScriptVariablesComponentPanel::_handle_context_menu(int p_id)
+{
+    switch (p_id)
+    {
+        case CM_RENAME_VARIABLE:
+            _tree->edit_selected(true);
+            break;
+        case CM_REMOVE_VARIABLE:
+            _confirm_removal(_tree->get_selected());
+            break;
+    }
+}
+
+bool OrchestratorScriptVariablesComponentPanel::_handle_add_new_item(const String& p_name)
+{
+    // Add the new variable and update the components display
+    return _script->create_variable(p_name).is_valid();
+}
+
+void OrchestratorScriptVariablesComponentPanel::_handle_item_selected()
+{
+    TreeItem* item = _tree->get_selected();
+
+    Ref<OScriptVariable> variable = _script->get_variable(item->get_text(0));
+    OrchestratorPlugin::get_singleton()->get_editor_interface()->edit_resource(variable);
+}
+
+void OrchestratorScriptVariablesComponentPanel::_handle_item_activated(TreeItem* p_item)
+{
+    Ref<OScriptVariable> variable = _script->get_variable(p_item->get_text(0));
+    OrchestratorPlugin::get_singleton()->get_editor_interface()->edit_resource(variable);
+}
+
+bool OrchestratorScriptVariablesComponentPanel::_handle_item_renamed(const String& p_old_name, const String& p_new_name)
+{
+    if (_get_existing_names().has(p_new_name))
+    {
+        _show_notification("A variable with the name '" + p_new_name + "' already exists.");
+        return false;
+    }
+
+    _script->rename_variable(p_old_name, p_new_name);
+    return true;
+}
+
+void OrchestratorScriptVariablesComponentPanel::_handle_remove(TreeItem* p_item)
+{
+    const String variable_name = p_item->get_text(0);
+    _script->remove_variable(variable_name);
+}
+
+void OrchestratorScriptVariablesComponentPanel::_handle_button_clicked(TreeItem* p_item, int p_column, int p_id, int p_mouse_button)
+{
+    Ref<OScriptVariable> variable = _script->get_variable(p_item->get_text(0));
+    if (!variable.is_valid())
+        return;
+
+    _tree->set_selected(p_item, 0);
+
+    // id 1 => warning
+
+    if (p_column == 0 && p_id == 2)
+    {
+        // Type clicked
+        Ref<OrchestratorEditorInspectorPluginVariable> plugin = OrchestratorPlugin::get_singleton()
+            ->get_editor_inspector_plugin<OrchestratorEditorInspectorPluginVariable>();
+
+        if (plugin.is_valid())
+            plugin->edit_classification(variable.ptr());
+    }
+    else if (p_column == 0 && p_id == 3)
+    {
+        // Visibility changed on variable
+        variable->set_exported(!variable->is_exported());
+        update();
+    }
+}
+
+Dictionary OrchestratorScriptVariablesComponentPanel::_handle_drag_data(const Vector2& p_position)
+{
+    Dictionary data;
+
+    TreeItem* selected = _tree->get_selected();
+    if (selected)
+    {
+        data["type"] = "variable";
+        data["variables"] = Array::make(selected->get_text(0));
+    }
+    return data;
+}
+
+void OrchestratorScriptVariablesComponentPanel::update()
+{
+    _clear_tree();
+
+    PackedStringArray variable_names = _script->get_variable_names();
+    if (!variable_names.is_empty())
+    {
+        HashMap<String, Ref<OScriptVariable>> categorized;
+        HashMap<String, Ref<OScriptVariable>> uncategorized;
+        HashMap<String, String> categorized_names;
+        for (const String& variable_name : variable_names)
+        {
+            Ref<OScriptVariable> variable = _script->get_variable(variable_name);
+            if (variable->is_grouped_by_category())
+            {
+                const String category = variable->get_category().to_lower();
+                const String sort_name = vformat("%s/%s", category, variable_name.to_lower());
+
+                categorized[variable_name] = variable;
+                categorized_names[sort_name] = variable_name;
+            }
+            else
+                uncategorized[variable_name] = variable;
+        }
+
+        // Sort categorized
+        PackedStringArray sorted_categorized_names;
+        for (const KeyValue<String, String>& E : categorized_names)
+            sorted_categorized_names.push_back(E.key);
+        sorted_categorized_names.sort();
+
+        // Sort uncategorized
+        PackedStringArray sorted_uncategorized_names;
+        for (const KeyValue<String, Ref<OScriptVariable>>& E : uncategorized)
+            sorted_uncategorized_names.push_back(E.key);
+        sorted_uncategorized_names.sort();
+
+        auto callable = callable_mp_lambda(this, [=]{ update(); });
+
+        TreeItem* root = _tree->get_root();
+        for (const String& sort_categorized_name : sorted_categorized_names)
+        {
+            const String variable_name = categorized_names[sort_categorized_name];
+            const Ref<OScriptVariable>& variable = categorized[variable_name];
+
+            if (variable.is_valid() && !variable->is_connected("changed", callable))
+                variable->connect("changed", callable);
+
+            _create_item(root, variable);
+        }
+
+        for (const String& sort_uncategorized_name : sorted_uncategorized_names)
+        {
+            const Ref<OScriptVariable>& variable = uncategorized[sort_uncategorized_name];
+            if (variable.is_valid() && !variable->is_connected("changed", callable))
+                variable->connect("changed", callable);
+
+            _create_item(root, variable);
+        }
+    }
+
+    if (_tree->get_root()->get_child_count() == 0)
+    {
+        TreeItem* item = _tree->get_root()->create_child();
+        item->set_text(0, "No variables defined");
+        item->set_selectable(0, false);
+        return;
+    }
+
+    OrchestratorScriptComponentPanel::update();
+}
+
+void OrchestratorScriptVariablesComponentPanel::_bind_methods()
+{
+}
+
+OrchestratorScriptVariablesComponentPanel::OrchestratorScriptVariablesComponentPanel(const Ref<OScript>& p_script)
+    : OrchestratorScriptComponentPanel("Variables", p_script)
+{
+}

--- a/src/editor/component_panels/variables_panel.h
+++ b/src/editor/component_panels/variables_panel.h
@@ -1,0 +1,66 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef ORCHESTRATOR_SCRIPT_VARIABLES_COMPONENT_PANEL_H
+#define ORCHESTRATOR_SCRIPT_VARIABLES_COMPONENT_PANEL_H
+
+#include "editor/component_panels/component_panel.h"
+
+class OrchestratorScriptVariablesComponentPanel : public OrchestratorScriptComponentPanel
+{
+    GDCLASS(OrchestratorScriptVariablesComponentPanel, OrchestratorScriptComponentPanel);
+    static void _bind_methods();
+
+    enum ContextMenuIds
+    {
+        CM_RENAME_VARIABLE,
+        CM_REMOVE_VARIABLE
+    };
+
+protected:
+    //~ Begin OrchestratorScriptViewSection Interface
+    String _get_unique_name_prefix() const override { return "NewVar"; }
+    PackedStringArray _get_existing_names() const override;
+    String _get_tooltip_text() const override;
+    String _get_remove_confirm_text(TreeItem* p_item) const override;
+    String _get_item_name() const override { return "Variable"; }
+    bool _populate_context_menu(TreeItem* p_item) override;
+    void _handle_context_menu(int p_id) override;
+    bool _handle_add_new_item(const String& p_name) override;
+    void _handle_item_selected() override;
+    void _handle_item_activated(TreeItem* p_item) override;
+    bool _handle_item_renamed(const String& p_old_name, const String& p_new_name) override;
+    void _handle_remove(TreeItem* p_item) override;
+    void _handle_button_clicked(TreeItem* p_item, int p_column, int p_id, int p_mouse_button) override;
+    Dictionary _handle_drag_data(const Vector2& p_position) override;
+    //~ End OrchestratorScriptViewSection Interface
+
+    void _create_item(TreeItem* p_parent, const Ref<OScriptVariable>& p_variable);
+
+    /// Default constructor
+    OrchestratorScriptVariablesComponentPanel() = default;
+
+public:
+    //~ Begin OrchestratorScriptViewSection Interface
+    void update() override;
+    //~ End OrchestratorScriptViewSection Interface
+
+    /// Constructs a variable component panel
+    /// @param p_script the script
+    explicit OrchestratorScriptVariablesComponentPanel(const Ref<OScript>& p_script);
+};
+
+#endif // ORCHESTRATOR_SCRIPT_VARIABLES_COMPONENT_PANEL_H

--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -17,6 +17,12 @@
 #include "editor.h"
 
 #include "about_dialog.h"
+#include "editor/component_panels/component_panel.h"
+#include "editor/component_panels/functions_panel.h"
+#include "editor/component_panels/graphs_panel.h"
+#include "editor/component_panels/macros_panel.h"
+#include "editor/component_panels/signals_panel.h"
+#include "editor/component_panels/variables_panel.h"
 #include "editor/getting_started.h"
 #include "editor/graph/actions/action_menu.h"
 #include "editor/graph/actions/default_action_registrar.h"
@@ -74,12 +80,12 @@ void register_editor_classes()
     ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorGettingStarted)
     ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptConnectionsDialog)
     ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptView)
-    ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptViewSection)
-    ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptViewGraphsSection)
-    ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptViewFunctionsSection)
-    ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptViewMacrosSection)
-    ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptViewVariablesSection)
-    ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptViewSignalsSection)
+    ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptComponentPanel)
+    ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptFunctionsComponentPanel)
+    ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptGraphsComponentPanel)
+    ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptMacrosComponentPanel)
+    ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptSignalsComponentPanel)
+    ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptVariablesComponentPanel)
 
     // Graph Classes
     ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorGraphEdit)

--- a/src/editor/graph/graph_edit.h
+++ b/src/editor/graph/graph_edit.h
@@ -25,7 +25,6 @@
 #include <godot_cpp/classes/curve2d.hpp>
 #include <godot_cpp/classes/editor_interface.hpp>
 #include <godot_cpp/classes/graph_edit.hpp>
-#include <godot_cpp/classes/input_event.hpp>
 #include <godot_cpp/classes/option_button.hpp>
 #include <godot_cpp/classes/timer.hpp>
 
@@ -159,6 +158,9 @@ public:
     /// Clear all selected nodes
     void clear_selection();
 
+    Vector<OrchestratorGraphNode*> get_selected_nodes();
+    Vector<Ref<OScriptNode>> get_selected_script_nodes();
+
     /// Causes the graph to tween focus the specified node in the graph.
     /// @param p_node_id the node's unique id
     /// @param p_animated whether to animate the movement, enabled by default
@@ -189,6 +191,8 @@ public:
     /// Perform an action for each graph node
     /// @param p_func the lambda to be applied
     void for_each_graph_node(std::function<void(OrchestratorGraphNode*)> p_func);
+
+    void execute_action(const String& p_action_name);
 
     //~ GraphEdit overrides
     bool _can_drop_data(const Vector2& p_position, const Variant& p_data) const override;
@@ -250,11 +254,6 @@ private:
     /// Update the saved mouse position
     /// @param p_position the position
     void _update_saved_mouse_position(const Vector2& p_position);
-
-    /// Returns whether the specified node can be duplicated.
-    /// @param p_node the node
-    /// @return true if the node can be duplicated, false otherwise
-    bool _can_duplicate_node(OrchestratorGraphNode* p_node) const;
 
     /// Displays the drag status hint
     /// @param p_message the hint message

--- a/src/editor/graph/graph_node.cpp
+++ b/src/editor/graph/graph_node.cpp
@@ -24,6 +24,7 @@
 #include "plugin/settings.h"
 #include "script/nodes/editable_pin_node.h"
 #include "script/nodes/functions/call_function.h"
+#include "script/nodes/functions/call_script_function.h"
 #include "script/script.h"
 
 #include <godot_cpp/classes/button.hpp>
@@ -436,6 +437,15 @@ void OrchestratorGraphNode::_show_context_menu(const Vector2& p_position)
     if (_is_editable())
         _context_menu->add_item("Add Option Pin", CM_ADD_OPTION_PIN);
 
+    _context_menu->add_separator("Organization");
+    _context_menu->add_item("Expand Node", CM_EXPAND_NODE);
+    _context_menu->add_item("Collapse to Function", CM_COLLAPSE_FUNCTION);
+
+    Ref<OScriptNodeCallScriptFunction> call_script_function = _node;
+    if (!call_script_function.is_valid())
+        _context_menu->set_item_disabled(_context_menu->get_item_index(CM_EXPAND_NODE), true);
+
+
     // todo: support breakpoints (See Trello)
     // _context_menu->add_separator("Breakpoints");
     // _context_menu->add_item("Toggle Breakpoint", CM_TOGGLE_BREAKPOINT, KEY_F9);
@@ -456,11 +466,7 @@ void OrchestratorGraphNode::_show_context_menu(const Vector2& p_position)
 
 void OrchestratorGraphNode::_simulate_action_pressed(const String& p_action_name)
 {
-    Ref<InputEventAction> action = memnew(InputEventAction());
-    action->set_action(p_action_name);
-    action->set_pressed(true);
-
-    Input::get_singleton()->parse_input_event(action);
+    get_graph()->execute_action(p_action_name);
 }
 
 void OrchestratorGraphNode::_on_changed()
@@ -628,6 +634,16 @@ void OrchestratorGraphNode::_on_context_menu_selection(int p_id)
             case CM_ADD_OPTION_PIN:
             {
                 _add_option_pin();
+                break;
+            }
+            case CM_COLLAPSE_FUNCTION:
+            {
+                get_graph()->emit_signal("collapse_selected_to_function");
+                break;
+            }
+            case CM_EXPAND_NODE:
+            {
+                get_graph()->emit_signal("expand_node", _node->get_id());
                 break;
             }
             #ifdef _DEBUG

--- a/src/editor/graph/graph_node.h
+++ b/src/editor/graph/graph_node.h
@@ -58,6 +58,8 @@ private:
         CM_TOGGLE_BREAKPOINT,
         CM_ADD_BREAKPOINT,
         CM_VIEW_DOCUMENTATION,
+        CM_COLLAPSE_FUNCTION,
+        CM_EXPAND_NODE,
         CM_RESIZABLE,
         #ifdef _DEBUG
         CM_SHOW_DETAILS = 999,

--- a/src/editor/main_view.cpp
+++ b/src/editor/main_view.cpp
@@ -39,7 +39,6 @@
 #include <godot_cpp/classes/label.hpp>
 #include <godot_cpp/classes/line_edit.hpp>
 #include <godot_cpp/classes/margin_container.hpp>
-#include <godot_cpp/classes/menu_bar.hpp>
 #include <godot_cpp/classes/menu_button.hpp>
 #include <godot_cpp/classes/node.hpp>
 #include <godot_cpp/classes/option_button.hpp>
@@ -69,6 +68,8 @@ void OrchestratorMainView::_notification(int p_what)
 {
     if (p_what == NOTIFICATION_READY)
     {
+        add_theme_stylebox_override("panel", SceneUtils::get_editor_style("ScriptEditorPanel"));
+
         // Load the recent files
         const Ref<ConfigFile> metadata = _plugin->get_metadata();
         _recent_files = metadata->get_value("recent_files", "orchestrations", {});
@@ -77,30 +78,15 @@ void OrchestratorMainView::_notification(int p_what)
         set_h_size_flags(SIZE_EXPAND_FILL);
         set_v_size_flags(SIZE_EXPAND_FILL);
 
-        MarginContainer* margin = memnew(MarginContainer);
-        margin->set_anchors_preset(PRESET_FULL_RECT);
-        margin->add_theme_constant_override("margin_left", 4);
-        margin->add_theme_constant_override("margin_top", 0);
-        margin->add_theme_constant_override("margin_right", 5);
-        margin->add_theme_constant_override("margin_bottom", 5);
-        add_child(margin);
-
         VBoxContainer* vbox = memnew(VBoxContainer);
-        vbox->add_theme_constant_override("separation", 0);
-        margin->add_child(vbox);
+        add_child(vbox);
 
         HBoxContainer* toolbar = memnew(HBoxContainer);
-        toolbar->set_custom_minimum_size(Vector2i(0, 32.0 * _plugin->get_editor_interface()->get_editor_scale()));
-        toolbar->add_theme_constant_override("separation", 0);
         vbox->add_child(toolbar);
 
-        MenuBar* left_menu = memnew(MenuBar);
+        HBoxContainer* left_menu = memnew(HBoxContainer);
         left_menu->set_h_size_flags(SIZE_EXPAND_FILL);
         toolbar->add_child(left_menu);
-
-        HBoxContainer* left_menu_container = memnew(HBoxContainer);
-        left_menu_container->add_theme_constant_override("separation", 0);
-        left_menu->add_child(left_menu_container);
 
         _file_menu = memnew(MenuButton);
         _file_menu->set_v_size_flags(SIZE_SHRINK_BEGIN);
@@ -135,7 +121,7 @@ void OrchestratorMainView::_notification(int p_what)
         _file_menu->get_popup()->connect("about_to_popup",
                                          callable_mp(this, &OrchestratorMainView::_on_prepare_file_menu));
         _file_menu->get_popup()->connect("popup_hide", callable_mp(this, &OrchestratorMainView::_on_file_menu_closed));
-        left_menu_container->add_child(_file_menu);
+        left_menu->add_child(_file_menu);
 
         _goto_menu = memnew(MenuButton);
         _goto_menu->set_v_size_flags(SIZE_SHRINK_BEGIN);
@@ -144,7 +130,7 @@ void OrchestratorMainView::_notification(int p_what)
         _goto_menu->get_popup()->add_item("Goto Node", AccelMenuIds::GOTO_NODE, SKEY(KEY_MASK_CTRL, KEY_L));
         _goto_menu->get_popup()->connect("id_pressed", callable_mp(this, &OrchestratorMainView::_on_menu_option));
         _goto_menu->get_popup()->connect("about_to_popup", callable_mp(this, &OrchestratorMainView::_on_prepare_goto_menu));
-        left_menu_container->add_child(_goto_menu);
+        left_menu->add_child(_goto_menu);
 
         _help_menu = memnew(MenuButton);
         _help_menu->set_v_size_flags(SIZE_SHRINK_BEGIN);
@@ -159,7 +145,7 @@ void OrchestratorMainView::_notification(int p_what)
         _help_menu->get_popup()->add_item("About " VERSION_NAME, AccelMenuIds::ABOUT);
         _help_menu->get_popup()->add_icon_item(SceneUtils::get_editor_icon("Heart"), "Support " VERSION_NAME, AccelMenuIds::SUPPORT);
         _help_menu->get_popup()->connect("id_pressed", callable_mp(this, &OrchestratorMainView::_on_menu_option));
-        left_menu_container->add_child(_help_menu);
+        left_menu->add_child(_help_menu);
 
         HBoxContainer* right_menu_container = memnew(HBoxContainer);
         right_menu_container->add_theme_constant_override("separation", 0);

--- a/src/editor/main_view.h
+++ b/src/editor/main_view.h
@@ -19,6 +19,7 @@
 
 #include <godot_cpp/classes/config_file.hpp>
 #include <godot_cpp/classes/control.hpp>
+#include <godot_cpp/classes/panel_container.hpp>
 #include <godot_cpp/templates/hash_map.hpp>
 #include <godot_cpp/templates/vector.hpp>
 
@@ -47,9 +48,9 @@ namespace godot
 }
 
 /// The plug-in main window
-class OrchestratorMainView : public Control
+class OrchestratorMainView : public PanelContainer
 {
-    GDCLASS(OrchestratorMainView, Control);
+    GDCLASS(OrchestratorMainView, PanelContainer);
 
 private:
     enum AccelMenuIds

--- a/src/editor/script_view.h
+++ b/src/editor/script_view.h
@@ -20,448 +20,87 @@
 #include "script/script.h"
 
 #include <godot_cpp/classes/confirmation_dialog.hpp>
-#include <godot_cpp/classes/h_box_container.hpp>
 #include <godot_cpp/classes/h_split_container.hpp>
 #include <godot_cpp/classes/input_event.hpp>
-#include <godot_cpp/classes/panel_container.hpp>
 #include <godot_cpp/classes/popup_menu.hpp>
 #include <godot_cpp/classes/scroll_container.hpp>
 #include <godot_cpp/classes/tab_container.hpp>
 #include <godot_cpp/classes/tree.hpp>
-#include <godot_cpp/classes/v_box_container.hpp>
 
 /// Forward declarations
 class OrchestratorGraphEdit;
 class OrchestratorPlugin;
 class OrchestratorMainView;
-
-namespace godot
-{
-    class ScrollContainer;
-}
-
-/// Represents a component section
-class OrchestratorScriptViewSection : public VBoxContainer
-{
-    GDCLASS(OrchestratorScriptViewSection, VBoxContainer);
-
-protected:
-    String _section_name;                     //! Name of the section
-    PanelContainer* _panel{ nullptr };        //! Panel container
-    HBoxContainer* _panel_hbox{ nullptr };    //! Panel HBox container
-    Tree* _tree{ nullptr };                   //! The tree list
-    Button* _collapse_button{ nullptr };      //! The collapse button
-    PopupMenu* _context_menu{ nullptr };      //! Context menu
-    ConfirmationDialog* _confirm{ nullptr };  //! Confirmation dialog
-    AcceptDialog* _notify{ nullptr };         //! Notification dialog
-    bool _expanded{ true };                   //! Whether the section is currently expanded
-    bool _theme_changing{ false };            //! Whether the theme is being changed
-
-    static void _bind_methods();
-
-    /// Clears the tree of all items but the root.
-    void _clear_tree();
-
-    /// Updates the state of the collapse button.
-    void _update_collapse_button_icon();
-
-    /// Toggles the visbility of the tree control.
-    void _toggle();
-
-    /// Notifies the user of a message.
-    /// @param p_message the text to notify
-    void _show_notification(const String& p_message);
-
-    /// Presents the user a dialog, confirming the removal of the tree item.
-    /// @param p_item the item to be removed, should not be null
-    void _confirm_removal(TreeItem* p_item);
-
-    /// Creates a unique name in the tree with the given prefix.
-    /// This is useful to guarantee that all new items have a unique name.
-    /// @param p_prefix the prefix to use
-    /// @return the new unique name
-    String _create_unique_name_with_prefix(const String& p_prefix);
-
-    /// Finds the specified child in the tree with text that matches the given name.
-    /// @param p_name the text to find and activate in the tree control
-    /// @param p_edit true if the item should be edited after activation, false otherwise
-    /// @return true if the item is found and activated, false otherwise
-    bool _find_child_and_activate(const String& p_name, bool p_edit = true);
-
-    /// Get the panel's horizontal box control
-    /// @return the HBoxContainer child of the top panel, never null
-    HBoxContainer* _get_panel_hbox();
-
-    /// Get all the existing names for a given element.
-    /// @return packed string array of all existing object names
-    virtual PackedStringArray _get_existing_names() const { return {}; }
-
-    /// Get the tooltip text for the panel header.
-    /// @return the tooltip text to be shown.
-    virtual String _get_tooltip_text() const { return {}; }
-
-    /// Get the confirmation dialog text to show on item removal.
-    /// @param p_item the item to be removed
-    /// @return the text to show in the dialog
-    virtual String _get_remove_confirm_text(TreeItem* p_item) const { return {}; }
-
-    /// Get the section item name, used for the add button tooltip
-    /// @return the name of what items are called in the tree view.
-    virtual String _get_section_item_name() const { return "item"; }
-
-    /// Populates the context menu with options
-    /// @param p_item the tree item to create a context menu for, never null
-    /// @return true if the context menu is to be shown, false to not show the popup
-    virtual bool _populate_context_menu(TreeItem* p_item) { return false; }
-
-    /// Handles context menu selections.
-    /// @param p_id the menu id selected
-    virtual void _handle_context_menu(int p_id) { }
-
-    /// Handles adding new items to the tree
-    virtual void _handle_add_new_item() { }
-
-    /// Handles when an item is activated
-    /// @param p_item the activated item, never null
-    virtual void _handle_item_activated(TreeItem* p_item) { }
-
-    /// Handles when an item is selected
-    virtual void _handle_item_selected() { }
-
-    /// Handles when an item is renamed
-    /// @param p_old_name the old name
-    /// @param p_new_name the new name
-    virtual void _handle_item_renamed(const String& p_old_name, const String& p_new_name) { }
-
-    /// Handles the removal of the item
-    /// @param p_item the tree item to be removed
-    virtual void _handle_remove(TreeItem* p_item) { }
-
-    /// Handles button click in the tree
-    /// @param p_item the tree item
-    /// @param p_column the tree column
-    /// @param p_id the button id
-    /// @param p_mouse_button the mouse button pressed
-    virtual void _handle_button_clicked(TreeItem* p_item, int p_column, int p_id, int p_mouse_button) { }
-
-    /// Generates a drag-and-drop dictionary data bucket
-    /// @param p_position the position where the drag started
-    /// @return data to be used for the draggable item, returning an empty Dictionary cancels the drag
-    virtual Dictionary _handle_drag_data(const Vector2& p_position) { return {}; }
-
-    OrchestratorScriptViewSection() = default;
-
-public:
-    /// Constructs a view section
-    /// @param p_section_name the name of the section
-    OrchestratorScriptViewSection(const String& p_section_name);
-
-    /// Godot's notification callback
-    /// @param p_what the notification type
-    void _notification(int p_what);
-
-    /// Handles Godot GUI input
-    /// @param p_event the input event
-    void _gui_input(const Ref<InputEvent>& p_event) override;
-
-    /// Updates this control, should be called by the script view
-    virtual void update();
-
-private:
-
-    /// Updates the control's theme.
-    void _update_theme();
-
-    /// Dispatched when the add button is pressed
-    void _on_add_pressed();
-
-    /// Dispatched when a tree item is activated
-    void _on_item_activated();
-
-    /// Dispatched when a tree item is edited
-    void _on_item_edited();
-
-    /// Dispatched when a tree item is selected
-    void _on_item_selected();
-
-    /// Dispatched when a mouse selection is made
-    /// @param p_position the mouse position
-    /// @param p_button the mouse button used
-    void _on_item_mouse_selected(const Vector2& p_position, int p_button);
-
-    /// Dispatched when the item's collapse state changes.
-    /// @param p_item the tree item, should not be null
-    void _on_item_collapsed(TreeItem* p_item);
-
-    /// Dispatched when a context menu item is pressed
-    /// @param p_id the menu item's id that was pressed
-    void _on_menu_id_pressed(int p_id);
-
-    /// Dispatched when the user accepts the removal confirmation dialog.
-    void _on_remove_confirmed();
-
-    /// Dispatched when a button in the tree is clicked
-    /// @param p_item the tree item
-    /// @param p_column the column index
-    /// @param p_id the button id
-    /// @param p_mouse_button the mouse button used to click
-    void _on_button_clicked(TreeItem* p_item, int p_column, int p_id, int p_mouse_button);
-
-    /// Dispatched when drag data is requested for the tree control.
-    /// @param p_position the position where the drag started
-    Variant _on_tree_drag_data(const Vector2& p_position);
-};
-
-/// Represents a component section for event graphs
-class OrchestratorScriptViewGraphsSection : public OrchestratorScriptViewSection
-{
-    GDCLASS(OrchestratorScriptViewGraphsSection, OrchestratorScriptViewSection);
-
-    enum ContextMenuIds
-    {
-        CM_OPEN_GRAPH,
-        CM_RENAME_GRAPH,
-        CM_REMOVE_GRAPH,
-        CM_FOCUS_FUNCTION,
-        CM_REMOVE_FUNCTION
-    };
-
-protected:
-    Ref<OScript> _script;
-
-    static void _bind_methods();
-
-    /// Notifies the script view to show the specified graph associated with the tree item
-    /// @param p_item the graph tree item, should not be null
-    void _show_graph_item(TreeItem* p_item);
-
-    /// Notifies the script view to focus a specific event node in the graph.
-    /// @param p_item the graph event item, should not be null
-    void _focus_graph_function(TreeItem* p_item);
-
-    /// Notifies the script view that a graph has been removed.
-    /// This is useful to close any views that pertain to the graph.
-    /// @param p_item the graph item, should not be null
-    void _remove_graph(TreeItem* p_item);
-
-    /// Notifies the script view that a graph function was removed.
-    /// @param p_item the graph function item, should not be null
-    void _remove_graph_function(TreeItem* p_item);
-
-    //~ Begin OrchestratorScriptViewSection Interface
-    PackedStringArray _get_existing_names() const override;
-    String _get_tooltip_text() const override;
-    String _get_remove_confirm_text(TreeItem* p_item) const override;
-    String _get_section_item_name() const override { return "EventGraph"; }
-    bool _populate_context_menu(TreeItem* p_item) override;
-    void _handle_context_menu(int p_id) override;
-    void _handle_add_new_item() override;
-    void _handle_item_activated(TreeItem* p_item) override;
-    void _handle_item_renamed(const String& p_old_name, const String& p_new_name) override;
-    void _handle_remove(TreeItem* p_item) override;
-    void _handle_button_clicked(TreeItem* p_item, int p_column, int p_id, int p_mouse_button) override;
-    //~ End OrchestratorScriptViewSection Interface
-
-    OrchestratorScriptViewGraphsSection() = default;
-
-public:
-    OrchestratorScriptViewGraphsSection(const Ref<OScript>& p_script);
-
-    //~ Begin OrchestratorScriptViewSection Interface
-    void update() override;
-    //~ End OrchestratorScriptViewSection Interface
-};
-
-/// Represents a component section for functions
-class OrchestratorScriptViewFunctionsSection : public OrchestratorScriptViewSection
-{
-    GDCLASS(OrchestratorScriptViewFunctionsSection, OrchestratorScriptViewSection);
-
-    enum ContextMenuIds
-    {
-        CM_OPEN_FUNCTION_GRAPH,
-        CM_RENAME_FUNCTION,
-        CM_REMOVE_FUNCTION
-    };
-
-protected:
-    Ref<OScript> _script;
-
-    static void _bind_methods();
-
-    /// Dispatched when the user requests to override a virtual function
-    void _on_override_virtual_function();
-
-    /// Notifies the script view to show the function graph and focus the entry node.
-    /// @param p_item the function graph tree item, should not be null
-    void _show_function_graph(TreeItem* p_item);
-
-    //~ Begin OrchestratorScriptViewSection Interface
-    PackedStringArray _get_existing_names() const override;
-    String _get_tooltip_text() const override;
-    String _get_remove_confirm_text(TreeItem* p_item) const override;
-    String _get_section_item_name() const override { return "Function"; }
-    bool _populate_context_menu(TreeItem* p_item) override;
-    void _handle_context_menu(int p_id) override;
-    void _handle_add_new_item() override;
-    void _handle_item_activated(TreeItem* p_item) override;
-    void _handle_item_renamed(const String& p_old_name, const String& p_new_name) override;
-    void _handle_remove(TreeItem* p_item) override;
-    void _handle_button_clicked(TreeItem* p_item, int p_column, int p_id, int p_mouse_button) override;
-    Dictionary _handle_drag_data(const Vector2& p_position) override;
-    //~ End OrchestratorScriptViewSection Interface
-
-    OrchestratorScriptViewFunctionsSection() = default;
-
-public:
-    OrchestratorScriptViewFunctionsSection(const Ref<OScript>& p_script);
-
-    /// Godot's notification callback
-    /// @param p_what the notification type
-    void _notification(int p_what);
-
-    //~ Begin OrchestratorScriptViewSection Interface
-    void update() override;
-    //~ End OrchestratorScriptViewSection Interface
-};
-
-/// Represents a component section for macros
-class OrchestratorScriptViewMacrosSection : public OrchestratorScriptViewSection
-{
-    GDCLASS(OrchestratorScriptViewMacrosSection, OrchestratorScriptViewSection);
-
-protected:
-    Ref<OScript> _script;
-
-    static void _bind_methods() { }
-
-    //~ Begin OrchestratorScriptViewSection Interface
-    String _get_tooltip_text() const override;
-    String _get_section_item_name() const override { return "Macro"; }
-    //~ End OrchestratorScriptViewSection Interface
-
-    OrchestratorScriptViewMacrosSection() = default;
-
-public:
-    OrchestratorScriptViewMacrosSection(const Ref<OScript>& p_script);
-
-    /// Godot's notification callback
-    /// @param p_what the notification type
-    void _notification(int p_what);
-
-    //~ Begin OrchestratorScriptViewSection Interface
-    void update() override;
-    //~ End OrchestratorScriptViewSection Interface
-};
-
-/// Represents a component section for variables
-class OrchestratorScriptViewVariablesSection : public OrchestratorScriptViewSection
-{
-    GDCLASS(OrchestratorScriptViewVariablesSection, OrchestratorScriptViewSection);
-
-    enum ContextMenuIds
-    {
-        CM_RENAME_VARIABLE,
-        CM_REMOVE_VARIABLE
-    };
-
-protected:
-    Ref<OScript> _script;
-
-    static void _bind_methods() { }
-
-    /// Dispatched when the variable resource is changed
-    void _on_variable_changed();
-
-    void _create_item(TreeItem* p_parent, const Ref<OScriptVariable>& p_variable);
-
-    //~ Begin OrchestratorScriptViewSection Interface
-    PackedStringArray _get_existing_names() const override;
-    String _get_tooltip_text() const override;
-    String _get_remove_confirm_text(TreeItem* p_item) const override;
-    String _get_section_item_name() const override { return "Variable"; }
-    bool _populate_context_menu(TreeItem* p_item) override;
-    void _handle_context_menu(int p_id) override;
-    void _handle_add_new_item() override;
-    void _handle_item_selected() override;
-    void _handle_item_activated(TreeItem* p_item) override;
-    void _handle_item_renamed(const String& p_old_name, const String& p_new_name) override;
-    void _handle_remove(TreeItem* p_item) override;
-    void _handle_button_clicked(TreeItem* p_item, int p_column, int p_id, int p_mouse_button) override;
-    Dictionary _handle_drag_data(const Vector2& p_position) override;
-    //~ End OrchestratorScriptViewSection Interface
-
-    OrchestratorScriptViewVariablesSection() = default;
-
-public:
-    OrchestratorScriptViewVariablesSection(const Ref<OScript>& p_script);
-
-    //~ Begin OrchestratorScriptViewSection Interface
-    void update() override;
-    //~ End OrchestratorScriptViewSection Interface
-};
-
-/// Represents a component section for signals
-class OrchestratorScriptViewSignalsSection : public OrchestratorScriptViewSection
-{
-    GDCLASS(OrchestratorScriptViewSignalsSection, OrchestratorScriptViewSection);
-
-    enum ContextMenuIds
-    {
-        CM_RENAME_SIGNAL,
-        CM_REMOVE_SIGNAL
-    };
-
-protected:
-    Ref<OScript> _script;
-
-    static void _bind_methods() { }
-
-    //~ Begin OrchestratorScriptViewSection Interface
-    PackedStringArray _get_existing_names() const override;
-    String _get_tooltip_text() const override;
-    String _get_remove_confirm_text(TreeItem* p_item) const override;
-    String _get_section_item_name() const override { return "Signal"; }
-    bool _populate_context_menu(TreeItem* p_item) override;
-    void _handle_context_menu(int p_id) override;
-    void _handle_add_new_item() override;
-    void _handle_item_selected() override;
-    void _handle_item_activated(TreeItem* p_item) override;
-    void _handle_item_renamed(const String& p_old_name, const String& p_new_name) override;
-    void _handle_remove(TreeItem* p_item) override;
-    Dictionary _handle_drag_data(const Vector2& p_position) override;
-    //~ End OrchestratorScriptViewSection Interface
-
-    OrchestratorScriptViewSignalsSection() = default;
-
-public:
-    OrchestratorScriptViewSignalsSection(const Ref<OScript>& p_script);
-
-    //~ Begin OrchestratorScriptViewSection Interface
-    void update() override;
-    //~ End OrchestratorScriptViewSection Interface
-};
+class OrchestratorScriptComponentPanel;
+class OrchestratorScriptFunctionsComponentPanel;
+class OrchestratorScriptGraphsComponentPanel;
+class OrchestratorScriptMacrosComponentPanel;
+class OrchestratorScriptSignalsComponentPanel;
+class OrchestratorScriptVariablesComponentPanel;
 
 /// Main Orchestrator Script View
 class OrchestratorScriptView : public HSplitContainer
 {
-    GDCLASS(OrchestratorScriptView, HSplitContainer);
+    friend class OrchestratorScriptFunctionsComponentPanel;
 
-private:
-    Ref<OScript> _script;                                //! The orchestrator script
-    TabContainer* _tabs{ nullptr };                      //! The tab container
-    ScrollContainer* _scroll_container{ nullptr };       //! The right component container
-    OrchestratorGraphEdit* _event_graph{ nullptr };      //! The standard event graph that cannot be removed
-    OrchestratorPlugin* _plugin{ nullptr };              //! Reference to the plug-in
-    OrchestratorMainView* _main_view{ nullptr };         //! The owning main view
-    OrchestratorScriptViewGraphsSection* _graphs;        //! Graphs section
-    OrchestratorScriptViewFunctionsSection* _functions;  //! Functions section
-    OrchestratorScriptViewMacrosSection* _macros;        //! Macros section
-    OrchestratorScriptViewVariablesSection* _variables;  //! Variables section
-    OrchestratorScriptViewSignalsSection* _signals;      //! Signals section
+    GDCLASS(OrchestratorScriptView, HSplitContainer);
+    static void _bind_methods() { }
+
+    // Represents all different types of active connections for a Vector<Ref<OScriptNode>> set.
+    struct NodeSetConnections
+    {
+        RBSet<OScriptConnection> connections;  //! Connections between the node set.
+        RBSet<OScriptConnection> inputs;       //! Connections that are inputs from outside the node set.
+        RBSet<OScriptConnection> outputs;      //! Connections that are outputs from the node set.
+        int input_executions{ 0 };             //! Number of node set execution inputs connected
+        int input_data{ 0 };                   //! Number of node set data inputs connected
+        int output_executions{ 0 };            //! Number of node set execution outputs connected
+        int output_data{ 0 };                  //! Number of node set data outputs connected
+    };
 
 protected:
-    static void _bind_methods() { }
+    Ref<OScript> _script;                                   //! The orchestrator script
+    TabContainer* _tabs{ nullptr };                         //! The tab container
+    ScrollContainer* _scroll_container{ nullptr };          //! The right component container
+    OrchestratorGraphEdit* _event_graph{ nullptr };         //! The standard event graph that cannot be removed
+    OrchestratorPlugin* _plugin{ nullptr };                 //! Reference to the plug-in
+    OrchestratorMainView* _main_view{ nullptr };            //! The owning main view
+    OrchestratorScriptGraphsComponentPanel* _graphs;        //! Graphs section
+    OrchestratorScriptFunctionsComponentPanel* _functions;  //! Functions section
+    OrchestratorScriptMacrosComponentPanel* _macros;        //! Macros section
+    OrchestratorScriptVariablesComponentPanel* _variables;  //! Variables section
+    OrchestratorScriptSignalsComponentPanel* _signals;      //! Signals section
+
+    /// Creates a new user-defined function
+    /// @param p_name the new function name
+    /// @param p_add_return_node whether to add a return node
+    /// @return the newly created function, or an invalid reference if the create failed
+    Ref<OScriptFunction> _create_new_function(const String& p_name, bool p_add_return_node = false);
+
+    /// Resolves the node set connections based on the provided set of nodes
+    /// @param p_nodes the nodes to resolve connections for
+    /// @param r_connections the popuplated connections structure
+    void _resolve_node_set_connections(const Vector<Ref<OScriptNode>>& p_nodes, NodeSetConnections& r_connections);
+
+    /// Calculates the Rect2 that bounds the provided set of nodes
+    /// @param p_nodes the nodes to calculate the bounding rect
+    /// @return the rect area that bounds the nodes
+    Rect2 _get_node_set_rect(const Vector<Ref<OScriptNode>>& p_nodes) const;
+
+    /// Moves nodes between two graphs
+    /// @param p_nodes the nodes to move
+    /// @param p_source the source graph to remove the node from
+    /// @param p_target the target graph to move the node to
+    void _move_nodes(const Vector<Ref<OScriptNode>>& p_nodes, const Ref<OScriptGraph>& p_source, const Ref<OScriptGraph>& p_target);
+
+    /// Collapse all selected nodes in the graph to a function
+    /// @param p_graph the graph to source the selected nodes from
+    void _collapse_selected_to_function(OrchestratorGraphEdit* p_graph);
+
+    /// Expands the seleced node in the graph, replacing the call node with the function's contents
+    /// @param p_node_id the node id to expand
+    /// @param p_graph the graph that contains this node
+    void _expand_node(int p_node_id, OrchestratorGraphEdit* p_graph);
 
     OrchestratorScriptView() = default;
 
@@ -531,38 +170,18 @@ private:
     /// @param p_tab_index the tab index
     void _close_tab(int p_tab_index);
 
-    /// Dispatched when a user requests a tab to be closed.
-    /// @param p_tab_index the tab's index
+    //~ Begin Signal handlers
     void _on_close_tab_requested(int p_tab_index);
-
-    /// Dispatched when a graph has changed
     void _on_graph_nodes_changed();
-
-    /// Dispatched when a node requests a specific object focus
     void _on_graph_focus_requested(Object* p_object);
-
-    /// Dispatched when a graph is requested to be opened and focused.
     void _on_show_graph(const String& p_graph_name);
-
-    /// Dispatched when a graph is requested to be closed, if its open.
     void _on_close_graph(const String& p_graph_name);
-
-    /// Dispatched when a graph is renamed
     void _on_graph_renamed(const String& p_old_name, const String& p_new_name);
-
-    /// Dispatched when a graph node is requested for focus.
     void _on_focus_node(const String& p_graph_name, int p_node_id);
-
-    /// Dispatched when function override is requested
     void _on_override_function();
-
-    /// Dispatched when the component panel's visibility should change
-    /// @param p_visible whether the panel is visible
     void _on_toggle_component_panel(bool p_visible);
-
-    /// Dispatched when requested to scroll to the specified item
-    /// @param p_item the tree item to scroll to
     void _on_scroll_to_item(TreeItem* p_item);
+    //~ End Signal handlers
 
     /// Dispatched when a user creates a signal connection via the Editor UI
     /// @param p_object the object to whom is being connected

--- a/src/script/function.cpp
+++ b/src/script/function.cpp
@@ -18,6 +18,7 @@
 
 #include "common/dictionary_utils.h"
 #include "common/method_utils.h"
+#include "nodes/functions/function_result.h"
 #include "script/script.h"
 
 void OScriptFunction::_get_property_list(List<PropertyInfo> *r_list) const
@@ -131,6 +132,38 @@ int OScriptFunction::get_owning_node_id() const
 Ref<OScriptNode> OScriptFunction::get_owning_node() const
 {
     return _script->get_node(_owning_node_id);
+}
+
+Ref<OScriptNode> OScriptFunction::get_return_node() const
+{
+    const Vector<Ref<OScriptNode>> nodes = get_return_nodes();
+    return nodes.is_empty() ? Ref<OScriptNode>() : nodes[0];
+}
+
+Vector<Ref<OScriptNode>> OScriptFunction::get_return_nodes() const
+{
+    Vector<Ref<OScriptNode>> results;
+
+    const Ref<OScriptGraph> graph = get_function_graph();
+    if (graph.is_valid())
+    {
+        TypedArray<int> nodes = graph->get_nodes();
+        for (int i = 0; i < nodes.size(); i++)
+        {
+            const Ref<OScriptNodeFunctionResult> result = _script->get_node(nodes[i]);
+            if (result.is_valid())
+                results.push_back(result);
+        }
+    }
+    return results;
+}
+
+Ref<OScriptGraph> OScriptFunction::get_function_graph() const
+{
+    if (_script->has_graph(get_function_name()))
+        return _script->get_graph(get_function_name());
+
+    return {};
 }
 
 Dictionary OScriptFunction::to_dict() const

--- a/src/script/function.h
+++ b/src/script/function.h
@@ -28,6 +28,7 @@ using namespace godot;
 
 /// Forward declarations
 class OScript;
+class OScriptGraph;
 class OScriptNode;
 
 /// An OrchestratorScript function resource
@@ -103,6 +104,18 @@ public:
     ///
     /// @return the owning script node reference, should always be valid.
     Ref<OScriptNode> get_owning_node() const;
+
+    /// Get the function's first return node, if any exist.
+    /// @return the first return node, or an invalid reference if none exist
+    Ref<OScriptNode> get_return_node() const;
+
+    /// Get the function's return nodes, if any exist
+    /// @return a vector of return nodes, may be empty
+    Vector<Ref<OScriptNode>> get_return_nodes() const;
+
+    /// Get the function graph
+    /// @return the graph this function is associated with
+    Ref<OScriptGraph> get_function_graph() const;
 
     /// Return the function definition as a Dictionary that contains a MethodInfo definition.
     /// In addition, the dictionary will include two custom properties,  "_oscript_guid" and

--- a/src/script/node.h
+++ b/src/script/node.h
@@ -356,6 +356,10 @@ public:
     /// @param p_pin the pin that was disconnected
     virtual void on_pin_disconnected(const Ref<OScriptNodePin>& p_pin);
 
+    /// Returns whether the node can be duplicated
+    /// @return if the node can be duplicated
+    virtual bool can_duplicate() const { return true; }
+
 protected:
 
     /// Notify that node pins have been changed.

--- a/src/script/nodes/functions/call_script_function.cpp
+++ b/src/script/nodes/functions/call_script_function.cpp
@@ -40,7 +40,9 @@ void OScriptNodeCallScriptFunction::post_initialize()
             _function_flags.set_flag(FF_IS_SELF);
             if (_is_in_editor())
             {
-                _function->connect("changed", callable_mp(this, &OScriptNodeCallScriptFunction::_on_function_changed));
+                Callable callable = callable_mp(this, &OScriptNodeCallScriptFunction::_on_function_changed);
+                if (!_function->is_connected("changed", callable))
+                    _function->connect("changed", callable);
             }
         }
     }
@@ -51,7 +53,11 @@ void OScriptNodeCallScriptFunction::post_placed_new_node()
 {
     super::post_placed_new_node();
     if (_function.is_valid() && _is_in_editor())
-        _function->connect("changed", callable_mp(this, &OScriptNodeCallScriptFunction::_on_function_changed));
+    {
+        Callable callable = callable_mp(this, &OScriptNodeCallScriptFunction::_on_function_changed);
+        if (!_function->is_connected("changed", callable))
+            _function->connect("changed", callable);
+    }
 }
 
 String OScriptNodeCallScriptFunction::get_tooltip_text() const

--- a/src/script/nodes/functions/event.h
+++ b/src/script/nodes/functions/event.h
@@ -48,6 +48,7 @@ public:
     String get_node_title_color_name() const override { return "events"; }
     String get_help_topic() const override;
     bool can_inspect_node_properties() const override { return true; }
+    bool can_duplicate() const override { return false; }
     StringName resolve_type_class(const Ref<OScriptNodePin>& p_pin) const override;
     //~ End OScriptNode Interface
 

--- a/src/script/nodes/functions/function_entry.h
+++ b/src/script/nodes/functions/function_entry.h
@@ -41,6 +41,7 @@ public:
     String get_tooltip_text() const override;
     void post_paste_node() override;
     bool draw_node_as_entry() const override { return true; }
+    bool can_duplicate() const override { return false; }
     bool can_create_user_defined_pin(EPinDirection p_direction, String& r_message) override;
     OScriptNodeInstance* instantiate(OScriptInstance* p_instance) override;
     void initialize(const OScriptNodeInitContext& p_context) override;

--- a/src/script/nodes/functions/function_result.h
+++ b/src/script/nodes/functions/function_result.h
@@ -47,6 +47,7 @@ public:
     bool is_compatible_with_graph(const Ref<OScriptGraph>& p_graph) const override;
     void post_placed_new_node() override;
     bool can_user_delete_node() const override;
+    bool can_duplicate() const override { return false; }
     OScriptNodeInstance* instantiate(OScriptInstance* p_instance) override;
     //~ End OScriptNode Interface
 

--- a/src/script/nodes/variables/local_variable.h
+++ b/src/script/nodes/variables/local_variable.h
@@ -43,6 +43,7 @@ public:
     String get_node_title_color_name() const override { return "variable"; }
     String get_tooltip_text() const override;
     bool is_compatible_with_graph(const Ref<OScriptGraph>& p_graph) const override;
+    bool can_duplicate() const override { return false; }
     OScriptNodeInstance* instantiate(OScriptInstance* p_instance) override;
     void initialize(const OScriptNodeInitContext& p_context) override;
     //~ End OScriptNode Interface


### PR DESCRIPTION
Fixes #156 

Given a graph like this one:

![image](https://github.com/Vahera/godot-orchestrator/assets/3255568/7fc7abce-c64f-4601-b808-95450b587dc1)

There is a new `Organization` section on the node context menu:

![image](https://github.com/Vahera/godot-orchestrator/assets/3255568/7b136f82-f48e-43cc-8498-1bef1068cd98)

With nodes selected, pick "Collapse to Function" to move the selected nodes to a new user-defined function:

![image](https://github.com/Vahera/godot-orchestrator/assets/3255568/be481671-4aab-4174-8f02-63d681cee9d8)
![image](https://github.com/Vahera/godot-orchestrator/assets/3255568/6a10edcb-0abb-4630-875e-84c346bcb71f)

On the context-menu, a user-defined script function can be expanded, which will replace the call script function node with the nodes from the child function, as follows:

![image](https://github.com/Vahera/godot-orchestrator/assets/3255568/934d5e6e-9029-42eb-93ab-2b5eede17113)

When expanding the following are not performed and left as exercises for the user:

1. Previous connections to the call function node are not preserved.
2. The function is not removed automatically; it's left in case it is used in other places.
