### PR TITLE
GH-343 Improve node styles, fidelity, and usability

### DIFF
--- a/src/common/scene_utils.cpp
+++ b/src/common/scene_utils.cpp
@@ -22,8 +22,8 @@
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/font.hpp>
 #include <godot_cpp/classes/label.hpp>
-#include <godot_cpp/classes/resource_loader.hpp>
 #include <godot_cpp/classes/scene_tree.hpp>
+#include <godot_cpp/classes/style_box.hpp>
 #include <godot_cpp/classes/theme.hpp>
 #include <godot_cpp/classes/theme_db.hpp>
 #include <godot_cpp/classes/v_box_container.hpp>
@@ -63,6 +63,18 @@ namespace SceneUtils
     {
         VBoxContainer* vbox = OrchestratorPlugin::get_singleton()->get_editor_interface()->get_editor_main_screen();
         return vbox->get_theme_icon(p_icon_name, "EditorIcons");
+    }
+
+    Ref<Font> get_editor_font(const String& p_font_name)
+    {
+        VBoxContainer* vbox = OrchestratorPlugin::get_singleton()->get_editor_interface()->get_editor_main_screen();
+        return vbox->get_theme_font(p_font_name, "EditorFonts");
+    }
+
+    Ref<StyleBox> get_editor_stylebox(const String& p_stylebox_name, const String& p_class_name)
+    {
+        VBoxContainer* vbox = OrchestratorPlugin::get_singleton()->get_editor_interface()->get_editor_main_screen();
+        return vbox->get_theme_stylebox(p_stylebox_name, p_class_name);
     }
 
     Ref<Texture2D> get_class_icon(const String& p_class_name, const String& p_fallback)

--- a/src/common/scene_utils.h
+++ b/src/common/scene_utils.h
@@ -18,6 +18,7 @@
 #define ORCHESTRATOR_SCENE_UTILS_H
 
 #include <godot_cpp/classes/control.hpp>
+#include <godot_cpp/classes/font.hpp>
 #include <godot_cpp/classes/margin_container.hpp>
 #include <godot_cpp/classes/node.hpp>
 #include <godot_cpp/classes/script.hpp>
@@ -38,6 +39,15 @@ namespace SceneUtils
     /// @param p_icon_name the editor icon to load
     /// @return a reference to the texture or an invalid reference if the texture isn't loaded
     Ref<Texture2D> get_editor_icon(const String& p_icon_name);
+
+    /// Get an editor font
+    /// @param p_font_name the font name
+    /// @return the font reference or an invalid reference if the font isn't found
+    Ref<Font> get_editor_font(const String& p_font_name);
+
+    /// Get an editor stylebox
+    /// @return the stylebox or an invalid reference if it wasn't found
+    Ref<StyleBox> get_editor_stylebox(const String& p_stylebox_name, const String& p_class_type);
 
     /// Loads the class icon
     ///

--- a/src/editor/graph/graph_edit.cpp
+++ b/src/editor/graph/graph_edit.cpp
@@ -18,6 +18,7 @@
 
 #include "common/dictionary_utils.h"
 #include "common/logger.h"
+#include "common/scene_utils.h"
 #include "common/version.h"
 #include "editor/graph/factories/graph_node_factory.h"
 #include "editor/graph/graph_node_pin.h"
@@ -39,6 +40,7 @@
 #include <godot_cpp/classes/scene_tree.hpp>
 #include <godot_cpp/classes/script_editor.hpp>
 #include <godot_cpp/classes/style_box_flat.hpp>
+#include <godot_cpp/classes/theme.hpp>
 #include <godot_cpp/classes/tween.hpp>
 
 OrchestratorGraphEdit::Clipboard* OrchestratorGraphEdit::_clipboard = nullptr;
@@ -86,7 +88,7 @@ EPinDirection OrchestratorGraphEdit::DragContext::get_direction() const
 OrchestratorGraphEdit::OrchestratorGraphEdit(OrchestratorPlugin* p_plugin, Ref<OScript> p_script, const String& p_name)
 {
     set_name(p_name);
-    set_minimap_enabled(false);
+    set_minimap_enabled(OrchestratorSettings::get_singleton()->get_setting("ui/graph/show_minimap", false));
     set_right_disconnects(true);
     set_show_arrange_button(false);
 
@@ -126,6 +128,8 @@ void OrchestratorGraphEdit::_notification(int p_what)
 {
     if (p_what == NOTIFICATION_READY)
     {
+        _update_theme();
+
         _drag_hint = memnew(Label);
         _drag_hint->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, 0);
         _drag_hint->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -50);
@@ -152,6 +156,11 @@ void OrchestratorGraphEdit::_notification(int p_what)
         _drag_hint_timer->set_wait_time(5);
         _drag_hint_timer->connect("timeout", callable_mp(this, &OrchestratorGraphEdit::_hide_drag_hint));
         add_child(_drag_hint_timer);
+
+        _theme_update_timer = memnew(Timer);
+        _theme_update_timer->set_wait_time(.5);
+        _theme_update_timer->set_one_shot(true);
+        add_child(_theme_update_timer);
 
         #if GODOT_VERSION >= 0x040300
         _grid_pattern = memnew(OptionButton);
@@ -502,6 +511,20 @@ void OrchestratorGraphEdit::_drop_data(const Vector2& p_position, const Variant&
             spawn_node(node, _saved_mouse_position);
         }
     }
+}
+
+void OrchestratorGraphEdit::_update_theme()
+{
+    Ref<Font> label_font = SceneUtils::get_editor_font("main_msdf");
+    Ref<Font> label_bold_font = SceneUtils::get_editor_font("main_bold_msdf");
+
+    Ref<Theme> theme(memnew(Theme));
+    theme->set_font("font", "Label", label_font);
+    theme->set_font("font", "GraphNodeTitleLabel", label_bold_font);
+    theme->set_font("font", "LineEdit", label_font);
+    theme->set_font("font", "Button", label_font);
+
+    set_theme(theme);
 }
 
 void OrchestratorGraphEdit::_focus_node(int p_node_id, bool p_animated)
@@ -1148,7 +1171,21 @@ void OrchestratorGraphEdit::_on_context_menu_selection(int p_id)
 
 void OrchestratorGraphEdit::_on_project_settings_changed()
 {
-    _synchronize_graph_with_script();
+    if (_theme_update_timer->is_stopped())
+    {
+        _theme_update_timer->start();
+
+        OrchestratorSettings* os = OrchestratorSettings::get_singleton();
+        bool show_icons = os->get_setting("ui/nodes/show_type_icons", true);
+        bool node_resizable = os->get_setting("ui/nodes/resizable_by_default", false);
+
+        set_minimap_enabled(os->get_setting("ui/graph/show_minimap", false));
+
+        for_each_graph_node([&](OrchestratorGraphNode* node) {
+            node->show_icons(show_icons);
+            node->set_resizable(node_resizable);
+        });
+    }
 }
 
 void OrchestratorGraphEdit::_on_inspect_script()

--- a/src/editor/graph/graph_edit.h
+++ b/src/editor/graph/graph_edit.h
@@ -116,6 +116,7 @@ class OrchestratorGraphEdit : public GraphEdit
     Control* _status{ nullptr };                           //! Displays status in the center of graphs
     Label* _drag_hint{ nullptr };                          //! Displays the drag status at the bottom of the graph
     Timer* _drag_hint_timer{ nullptr };                    //! Timer for drag hint messages
+    Timer* _theme_update_timer{ nullptr };
     OrchestratorGraphEdit() = default;
 
 protected:
@@ -196,6 +197,9 @@ public:
     //~ End GraphEdit overrides
 
 private:
+    /// Updates the GraphEdit theme
+    void _update_theme();
+
     /// Moves the center of the graph to the node, optionally animating the movement.
     /// @param p_node_id the node's unique id, should be greater or equal-to 0.
     /// @param p_animated whether to animate the movement, enabled by default.

--- a/src/editor/graph/graph_node.h
+++ b/src/editor/graph/graph_node.h
@@ -58,6 +58,7 @@ private:
         CM_TOGGLE_BREAKPOINT,
         CM_ADD_BREAKPOINT,
         CM_VIEW_DOCUMENTATION,
+        CM_RESIZABLE,
         #ifdef _DEBUG
         CM_SHOW_DETAILS = 999,
         #endif
@@ -141,6 +142,9 @@ public:
 
     /// Unlinks all connections to all pins on this node
     void unlink_all();
+
+    /// Set whether node icons are shown
+    virtual void show_icons(bool p_show_icons) { }
 
     /// Get a list of nodes within this node's global rect.
     List<OrchestratorGraphNode*> get_nodes_within_global_rect();

--- a/src/editor/graph/graph_node_pin.cpp
+++ b/src/editor/graph/graph_node_pin.cpp
@@ -222,6 +222,12 @@ void OrchestratorGraphNodePin::set_default_value_control_visibility(bool p_visib
         _default_value->set_visible(p_visible);
 }
 
+void OrchestratorGraphNodePin::show_icon(bool p_visible)
+{
+    if (_icon)
+        _icon->set_visible(p_visible);
+}
+
 void OrchestratorGraphNodePin::_remove_editable_pin()
 {
     Ref<OScriptEditablePinNode> editable = _node->get_script_node();
@@ -307,8 +313,8 @@ void OrchestratorGraphNodePin::_create_widgets()
             HBoxContainer* row0 = memnew(HBoxContainer);
             vbox->add_child(row0);
 
-            if (!is_execution() && show_icons)
-                row0->add_child(_create_type_icon());
+            if (!is_execution())
+                row0->add_child(_create_type_icon(true));
 
             Label* label = _create_label();
             label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_LEFT);
@@ -328,8 +334,8 @@ void OrchestratorGraphNodePin::_create_widgets()
         }
         else
         {
-            if (!is_execution() && show_icons)
-                add_child(_create_type_icon());
+            if (!is_execution())
+                add_child(_create_type_icon(show_icons));
 
             Label* label = _create_label();
             label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_LEFT);
@@ -356,22 +362,22 @@ void OrchestratorGraphNodePin::_create_widgets()
         label->set_v_size_flags(SIZE_SHRINK_CENTER);
         add_child(label);
 
-        if (!is_execution() && show_icons)
-            add_child(_create_type_icon());
+        if (!is_execution())
+            add_child(_create_type_icon(show_icons));
     }
 }
 
-TextureRect* OrchestratorGraphNodePin::_create_type_icon()
+TextureRect* OrchestratorGraphNodePin::_create_type_icon(bool p_visible)
 {
-    TextureRect* rect = memnew(TextureRect);
+    _icon = memnew(TextureRect);
     String value_type_name = _pin->get_pin_type_name();
-    rect->set_texture(SceneUtils::get_editor_icon(value_type_name));
-    rect->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
+    _icon->set_texture(SceneUtils::get_editor_icon(value_type_name));
+    _icon->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
 
-    if (_pin->get_flags().has_flag(OScriptNodePin::Flags::HIDDEN))
-        rect->set_visible(false);
+    if (_pin->get_flags().has_flag(OScriptNodePin::Flags::HIDDEN) || !p_visible)
+        _icon->set_visible(false);
 
-    return rect;
+    return _icon;
 }
 
 Label* OrchestratorGraphNodePin::_create_label()

--- a/src/editor/graph/graph_node_pin.h
+++ b/src/editor/graph/graph_node_pin.h
@@ -72,6 +72,7 @@ protected:
     };
 
     OrchestratorGraphNode* _node{ nullptr };    //! The owning node
+    TextureRect* _icon{ nullptr };              //! The pin's icon
     Control* _default_value{ nullptr };         //! The default value control
     PopupMenu* _context_menu{ nullptr };        //! The context menu
     Ref<OScriptNodePin> _pin;                   //! The script pin reference
@@ -197,6 +198,10 @@ public:
     /// @param p_visible whether the control is visible
     void set_default_value_control_visibility(bool p_visible);
 
+    /// Whether the icons are shown
+    /// @param p_visible whether to show the icon
+    void show_icon(bool p_visible);
+
 private:
 
     void _select_nodes_for_pin(const Ref<OScriptNodePin>& p_pin);
@@ -213,8 +218,9 @@ private:
     String _create_promoted_variable_name();
 
     /// Creates the pin's rendered icon
+    /// @param p_visible whether the icon is visible
     /// @return the icon texture rect
-    TextureRect* _create_type_icon();
+    TextureRect* _create_type_icon(bool p_visible);
 
     /// Creates the pin's label
     /// @return the label

--- a/src/editor/graph/nodes/graph_node_comment.cpp
+++ b/src/editor/graph/nodes/graph_node_comment.cpp
@@ -68,11 +68,11 @@ void OrchestratorGraphNodeComment::_update_pins()
         }
     }
 
-    Ref<StyleBoxFlat> panel = get_theme_stylebox("panel");
+    Ref<StyleBoxFlat> panel = get_theme_stylebox("panel")->duplicate(true);
     panel->set_bg_color(_comment_node->get_background_color());
     add_theme_stylebox_override("panel", panel);
 
-    Ref<StyleBoxFlat> panel_selected = get_theme_stylebox("panel_selected");
+    Ref<StyleBoxFlat> panel_selected = get_theme_stylebox("panel_selected")->duplicate(true);
     panel_selected->set_bg_color(_comment_node->get_background_color());
     add_theme_stylebox_override("panel_selected", panel_selected);
 

--- a/src/editor/graph/nodes/graph_node_default.cpp
+++ b/src/editor/graph/nodes/graph_node_default.cpp
@@ -177,3 +177,15 @@ OrchestratorGraphNodePin* OrchestratorGraphNodeDefault::get_output_pin(int p_por
     ERR_FAIL_COND_V_MSG(p_port >= int(_pin_rows.size()), nullptr, "Failed to find row for slot " + itos(p_port));
     return _pin_rows[get_output_port_slot(p_port)].right;
 }
+
+void OrchestratorGraphNodeDefault::show_icons(bool p_visible)
+{
+    for (const KeyValue<int, Row>& E : _pin_rows)
+    {
+        if (E.value.left)
+            E.value.left->show_icon(p_visible);
+
+        if (E.value.right)
+            E.value.right->show_icon(p_visible);
+    }
+}

--- a/src/editor/graph/nodes/graph_node_default.h
+++ b/src/editor/graph/nodes/graph_node_default.h
@@ -76,6 +76,7 @@ public:
     //~ Begin OrchestratorGraphNode Interface
     OrchestratorGraphNodePin* get_input_pin(int p_port) override;
     OrchestratorGraphNodePin* get_output_pin(int p_port) override;
+    void show_icons(bool p_visible) override;
     //~ End OrchestratorGraphNode Interface
 };
 

--- a/src/plugin/plugin.cpp
+++ b/src/plugin/plugin.cpp
@@ -77,6 +77,8 @@ void OrchestratorPlugin::_notification(int p_what)
         _window_wrapper->hide();
         _window_wrapper->connect("window_visibility_changed", callable_mp(this, &OrchestratorPlugin::_on_window_visibility_changed));
 
+        _theme_cache.instantiate();
+
         _make_visible(false);
     }
     else if (p_what == NOTIFICATION_EXIT_TREE)
@@ -308,4 +310,5 @@ void register_plugin_classes()
 
     ORCHESTRATOR_REGISTER_CLASS(OrchestratorEditorInspectorPluginVariable)
     ORCHESTRATOR_REGISTER_CLASS(OrchestratorEditorPropertyVariableClassification)
+    ORCHESTRATOR_REGISTER_CLASS(OrchestratorThemeCache)
 }

--- a/src/plugin/plugin.h
+++ b/src/plugin/plugin.h
@@ -17,6 +17,8 @@
 #ifndef ORCHESTRATOR_PLUGIN_H
 #define ORCHESTRATOR_PLUGIN_H
 
+#include "plugin/theme_cache.h"
+
 #include <godot_cpp/classes/config_file.hpp>
 #include <godot_cpp/classes/editor_plugin.hpp>
 #include <godot_cpp/classes/editor_inspector_plugin.hpp>
@@ -41,6 +43,7 @@ class OrchestratorPlugin : public EditorPlugin
     OrchestratorMainView* _main_view{ nullptr };              //! Plugin's main view
     OrchestratorWindowWrapper* _window_wrapper{ nullptr };    //! Window wrapper
     Vector<Ref<EditorInspectorPlugin>> _inspector_plugins;
+    Ref<OrchestratorThemeCache> _theme_cache;
 
 public:
     /// Constructor
@@ -83,6 +86,8 @@ public:
     /// Saves the metadata
     /// @param p_metadata the metadata to save
     void save_metadata(const Ref<ConfigFile>& p_metadata);
+
+    Ref<OrchestratorThemeCache> get_theme_cache() { return _theme_cache; }
 
     //~ Begin EditorPlugin interface
     String get_plugin_version() const;

--- a/src/plugin/settings.cpp
+++ b/src/plugin/settings.cpp
@@ -125,6 +125,9 @@ void OrchestratorSettings::_register_deprecated_settings()
     _removed.emplace_back(COLOR_NO_ALPHA_SETTING("nodes/colors/terminal", Color(0.2706, 0.3686, 0.4314)));
     _removed.emplace_back(COLOR_NO_ALPHA_SETTING("nodes/colors/utility", Color(0.5765, 0.1686, 0.4275)));
     _removed.emplace_back(COLOR_NO_ALPHA_SETTING("nodes/colors/custom", Color(0.47, 0.27, 0.20)));
+
+    // Deprecated with Orchestrator v2
+    _removed.emplace_back(BOOL_SETTING("ui/nodes/show_conversion_nodes", false));
 }
 
 void OrchestratorSettings::_register_settings()
@@ -140,9 +143,15 @@ void OrchestratorSettings::_register_settings()
 
     _settings.emplace_back(BOOL_SETTING("ui/actions_menu/center_on_mouse", true));
 
+    _settings.emplace_back(BOOL_SETTING("ui/graph/show_minimap", false));
+
     _settings.emplace_back(BOOL_SETTING("ui/nodes/show_type_icons", true));
-    _settings.emplace_back(BOOL_SETTING("ui/nodes/show_conversion_nodes", false));
+    _settings.emplace_back(BOOL_SETTING("ui/nodes/resizable_by_default", false));
     _settings.emplace_back(BOOL_SETTING("ui/nodes/highlight_selected_connections", false));
+    _settings.emplace_back(COLOR_NO_ALPHA_SETTING("ui/nodes/background_color", Color::html("#191d23")));
+    _settings.emplace_back(COLOR_NO_ALPHA_SETTING("ui/nodes/border_color", Color(0.059f, 0.067f, 0.082f)));
+    _settings.emplace_back(COLOR_NO_ALPHA_SETTING("ui/nodes/border_selected_color", Color(0.68f, 0.44f, 0.09f)));
+    _settings.emplace_back(RANGE_SETTING("ui/nodes/border_width", "0,8,1", 2));
 
     // Nodes
     _settings.emplace_back(COLOR_NO_ALPHA_SETTING("ui/node_colors/constants_and_literals", Color(0.271, 0.392, 0.2)));

--- a/src/plugin/settings.h
+++ b/src/plugin/settings.h
@@ -28,6 +28,7 @@ class OrchestratorSettings : public Object
 
     static void _bind_methods() {}
 
+public:
     struct Setting
     {
         PropertyInfo info;
@@ -36,6 +37,7 @@ class OrchestratorSettings : public Object
         explicit Setting(const PropertyInfo& p_info, const Variant& p_value) : info(p_info), value(p_value) {}
     };
 
+private:
     static OrchestratorSettings* _singleton;
     std::vector<Setting> _removed;
     std::vector<Setting> _settings;
@@ -69,6 +71,8 @@ public:
     /// Removes an action category favorite.
     /// @param p_action_name the action category to be removed
     void remove_action_favorite(const String& p_action_name);
+
+    const std::vector<Setting>& get_settings() const { return _settings; }
 
 private:
 

--- a/src/plugin/theme_cache.cpp
+++ b/src/plugin/theme_cache.cpp
@@ -1,0 +1,197 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "plugin/theme_cache.h"
+
+#include "common/scene_utils.h"
+#include "plugin/settings.h"
+
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/graph_node.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/style_box_flat.hpp>
+#include <godot_cpp/classes/window.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+void OrchestratorThemeCache::_settings_changed()
+{
+    // Connect to this signal if it hasn't been connected yet
+    Callable handler = callable_mp(this, &OrchestratorThemeCache::_settings_changed);
+    if (!ProjectSettings::get_singleton()->is_connected("settings_changed", handler))
+        ProjectSettings::get_singleton()->connect("settings_changed", handler);
+
+    OrchestratorSettings* settings = OrchestratorSettings::get_singleton();
+
+    const Color border = settings->get_setting("ui/nodes/border_color", Color(0, 0, 0));
+    const Color select = settings->get_setting("ui/nodes/border_selected_color", Color(0.68f, 0.44f, 0.09f));
+    const Color bkgrnd = settings->get_setting("ui/nodes/background_color", Color::html("#191d23"));
+    const float bwidth = settings->get_setting("ui/nodes/border_width", 2);
+
+    Ref<StyleBoxFlat> panel = get_theme_stylebox("panel", "GraphNode");
+    if (!panel.is_valid())
+    {
+        // Not yet primed.
+        Ref<StyleBoxFlat> new_panel = _get_editor_theme_stylebox("panel", "GraphNode")->duplicate(true);
+        if (new_panel.is_valid())
+        {
+            new_panel->set_border_color(border);
+            new_panel->set_border_width_all(bwidth);
+            new_panel->set_border_width(SIDE_TOP, 0);
+            new_panel->set_content_margin_all(2);
+            new_panel->set_content_margin(SIDE_BOTTOM, 6);
+            new_panel->set_corner_radius(CORNER_TOP_LEFT, 0);
+            new_panel->set_corner_radius(CORNER_TOP_RIGHT, 0);
+            new_panel->set_bg_color(bkgrnd);
+
+            add_theme_stylebox("panel", "GraphNode", new_panel);
+
+            Ref<StyleBoxFlat> panel_selected = new_panel->duplicate();
+            if (panel_selected.is_valid())
+            {
+                panel_selected->set_border_color(select);
+                add_theme_stylebox("panel_selected", "GraphNode", panel_selected);
+            }
+        }
+    }
+    else
+    {
+        if (panel->get_border_color() != border)
+            panel->set_border_color(border);
+
+        if (panel->get_bg_color() != bkgrnd)
+            panel->set_bg_color(bkgrnd);
+
+        if (!UtilityFunctions::is_equal_approx(panel->get_border_width(SIDE_LEFT), bwidth))
+        {
+            panel->set_border_width_all(bwidth);
+            panel->set_border_width(SIDE_TOP, 0);
+        }
+
+        Ref<StyleBoxFlat> panel_selected = get_theme_stylebox("panel_selected", "GraphNode");
+        if (panel_selected.is_valid())
+        {
+            if (panel_selected->get_bg_color() != bkgrnd)
+                panel_selected->set_bg_color(bkgrnd);
+
+            if (panel_selected->get_border_color() != select)
+                panel_selected->set_border_color(select);
+
+            if (!UtilityFunctions::is_equal_approx(panel_selected->get_border_width(SIDE_LEFT), bwidth))
+            {
+                panel_selected->set_border_width_all(bwidth);
+                panel_selected->set_border_width(SIDE_TOP, 0);
+            }
+        }
+    }
+
+    for (const OrchestratorSettings::Setting& setting : settings->get_settings())
+    {
+        if (!setting.info.name.begins_with("ui/node_colors/"))
+            continue;
+
+        const Color color = settings->get_setting(setting.info.name);
+        const PackedStringArray parts = setting.info.name.split("/");
+        const String type_name = vformat("GraphNode_%s", parts[parts.size() - 1]);
+
+        Ref<StyleBoxFlat> titlebar = get_theme_stylebox("titlebar", type_name);
+        if (!titlebar.is_valid())
+        {
+            Ref<StyleBoxFlat> new_titlebar = _get_editor_theme_stylebox("titlebar", "GraphNode")->duplicate(true);
+            if (new_titlebar.is_valid())
+            {
+                new_titlebar->set_bg_color(color);
+                new_titlebar->set_border_width_all(bwidth);
+                new_titlebar->set_border_width(SIDE_BOTTOM, 0);
+                new_titlebar->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+                new_titlebar->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+
+                new_titlebar->set_content_margin_all(4);
+                new_titlebar->set_content_margin(SIDE_LEFT, 12);
+                new_titlebar->set_content_margin(SIDE_RIGHT, 12);
+                new_titlebar->set_border_color(border);
+
+                add_theme_stylebox("titlebar", type_name, new_titlebar);
+
+                Ref<StyleBoxFlat> titlebar_selected = new_titlebar->duplicate();
+                if (titlebar_selected.is_valid())
+                {
+                    titlebar_selected->set_border_color(select);
+                    add_theme_stylebox("titlebar_selected", type_name, titlebar_selected);
+                }
+            }
+        }
+        else
+        {
+            if (titlebar->get_bg_color() != color || titlebar->get_border_color() != border)
+            {
+                // Primed, but color changed
+                titlebar->set_bg_color(color);
+                titlebar->set_border_color(border);
+            }
+
+            if (!UtilityFunctions::is_equal_approx(titlebar->get_border_width(SIDE_LEFT), bwidth))
+            {
+                titlebar->set_border_width_all(bwidth);
+                titlebar->set_border_width(SIDE_BOTTOM, 0);
+            }
+
+            const Ref<StyleBoxFlat> titlebar_selected = get_theme_stylebox("titlebar_selected", type_name);
+            if (titlebar_selected.is_valid())
+            {
+                if (titlebar_selected->get_bg_color() != color)
+                    titlebar_selected->set_bg_color(color);
+                if (titlebar_selected->get_border_color() != select)
+                    titlebar_selected->set_border_color(select);
+
+                if (!UtilityFunctions::is_equal_approx(titlebar_selected->get_border_width(SIDE_LEFT), bwidth))
+                {
+                    titlebar_selected->set_border_width_all(bwidth);
+                    titlebar_selected->set_border_width(SIDE_BOTTOM, 0);
+                }
+            }
+        }
+    }
+}
+
+void OrchestratorThemeCache::add_theme_stylebox(const StringName& p_name, const String& p_type_name, const Ref<StyleBox>& p_stylebox)
+{
+    if (!_stylebox_cache.has(p_type_name))
+        _stylebox_cache[p_type_name] = HashMap<StringName, Ref<StyleBox>>();
+
+    _stylebox_cache[p_type_name][p_name] = p_stylebox;
+}
+
+Ref<StyleBox> OrchestratorThemeCache::get_theme_stylebox(const StringName& p_name, const String& p_type_name) const
+{
+    if (_stylebox_cache.has(p_type_name))
+    {
+        const HashMap<StringName, Ref<StyleBox>>& second_level = _stylebox_cache[p_type_name];
+        if (second_level.has(p_name))
+            return second_level[p_name];
+    }
+    return nullptr;
+}
+
+Ref<StyleBox> OrchestratorThemeCache::_get_editor_theme_stylebox(const String& p_name, const String& p_type_name) const
+{
+    return SceneUtils::get_editor_stylebox(p_name, p_type_name);
+}
+void OrchestratorThemeCache::_notification(int p_what)
+{
+    if (p_what == NOTIFICATION_POSTINITIALIZE)
+        callable_mp(this, &OrchestratorThemeCache::_settings_changed).call_deferred();
+}
+

--- a/src/plugin/theme_cache.h
+++ b/src/plugin/theme_cache.h
@@ -1,0 +1,64 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef ORCHESTRATOR_THEME_CACHE_H
+#define ORCHESTRATOR_THEME_CACHE_H
+
+#include "godot_cpp/templates/hash_map.hpp"
+
+#include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/classes/style_box.hpp>
+
+using namespace godot;
+
+/// A simple class that manages the themes used by the Orchestrator plugin.
+class OrchestratorThemeCache : public RefCounted
+{
+    GDCLASS(OrchestratorThemeCache, RefCounted);
+    static void _bind_methods() {}
+
+protected:
+    HashMap<StringName, HashMap<StringName, Ref<StyleBox>>> _stylebox_cache;
+
+    //~ Begin Signal Handlers
+    void _settings_changed();
+    //~ End Signal Handlers
+
+public:
+    //~ Begn Wrapped Interface
+    void _notification(int p_what);
+    //~ End Wrapped Interface
+
+    /// Adds a theme stylebox to the cache
+    /// @param p_name the name
+    /// @param p_type_name the type name
+    /// @param p_stylebox the stylebox to cache
+    void add_theme_stylebox(const StringName& p_name, const String& p_type_name, const Ref<StyleBox>& p_stylebox);
+
+    /// Get a theme stylebox from the cache
+    /// @param p_name the name
+    /// @param p_type_name the type name
+    /// @returns the stylebox from the cache or an invalid stylebox reference if it doesn't exist
+    Ref<StyleBox> get_theme_stylebox(const StringName& p_name, const String& p_type_name) const;
+
+    /// Gets the editor theme stylebox
+    /// @param p_name the item name
+    /// @param p_type_name the type name
+    /// @return the editor stylebox theme, should always be valid
+    Ref<StyleBox>_get_editor_theme_stylebox(const String& p_name, const String& p_type_name) const;
+};
+
+#endif // ORCHESTRATOR_THEME_CACHE_H


### PR DESCRIPTION
Fixes #343 

![image](https://github.com/Vahera/godot-orchestrator/assets/3255568/f26dc496-35a5-4e3e-b32e-cd060298077e)

* Improve the responsiveness of theme changes.
* Move node resizing to a togglable feature using off as the default, with an on/off by default setting in project settings.
* Make the node background, border color, and selected border colors configurable
* Configure whether the minimap is shown or hidden by default in the project settings.

![image](https://github.com/Vahera/godot-orchestrator/assets/3255568/91e1637f-6e15-475c-8b06-fc6f535c5116)

* Use the same msdf editor font as the Visual Shader, improving the text fidelity at higher zoom levels.
* Apply the border color uniformly around the entire node, like the visual shader UI.
* Adjust the default border color to be charcoal grey rather than black.
