### PR TITLE
Add/Align usage of static `_bind_methods` in node classes

### DIFF
--- a/src/script/nodes/constants/constants.h
+++ b/src/script/nodes/constants/constants.h
@@ -23,6 +23,7 @@
 class OScriptNodeConstant : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeConstant, OScriptNode);
+    static void _bind_methods() { }
 
 public:
     OScriptNodeConstant();
@@ -36,6 +37,7 @@ public:
 class OScriptNodeGlobalConstant : public OScriptNodeConstant
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeGlobalConstant, OScriptNodeConstant);
+    static void _bind_methods() { }
 
 protected:
     StringName _constant_name;
@@ -69,6 +71,7 @@ public:
 class OScriptNodeMathConstant : public OScriptNodeConstant
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeMathConstant, OScriptNodeConstant);
+    static void _bind_methods() { }
 
 protected:
     String _constant_name{ "One" };  //! The math constant
@@ -96,6 +99,7 @@ public:
 class OScriptNodeTypeConstant : public OScriptNodeConstant
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeTypeConstant, OScriptNodeConstant);
+    static void _bind_methods();
 
     static Vector<Variant::Type> _types;
     static HashMap<Variant::Type, HashMap<StringName, Variant>> _type_constants;
@@ -109,8 +113,6 @@ protected:
     bool _get(const StringName& p_name, Variant& r_value) const;
     bool _set(const StringName& p_name, const Variant& p_value);
     //~ End Wrapped Interface
-
-    static void _bind_methods();
 
 public:
     //~ Begin OScriptNode Interface
@@ -129,6 +131,7 @@ public:
 class OScriptNodeClassConstantBase : public OScriptNodeConstant
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeClassConstantBase, OScriptNodeConstant);
+    static void _bind_methods() { }
 
 protected:
     String _class_name;     //! Constant class name
@@ -165,6 +168,7 @@ public:
 class OScriptNodeClassConstant : public OScriptNodeClassConstantBase
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeClassConstant, OScriptNodeClassConstantBase);
+    static void _bind_methods() { }
 
 protected:
     //~ Begin OScriptNodeClassConstantBase Interface
@@ -183,6 +187,7 @@ public:
 class OScriptNodeSingletonConstant : public OScriptNodeClassConstantBase
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeSingletonConstant, OScriptNodeClassConstantBase);
+    static void _bind_methods() { }
 
 protected:
     PackedStringArray _singletons;    //! Cached list of applicable singletons

--- a/src/script/nodes/data/arrays.h
+++ b/src/script/nodes/data/arrays.h
@@ -23,7 +23,8 @@
 /// Creates a new array
 class OScriptNodeMakeArray : public OScriptEditablePinNode
 {
-    ORCHESTRATOR_NODE_CLASS(OScriptNodeMakeArray, OScriptEditablePinNode)
+    ORCHESTRATOR_NODE_CLASS(OScriptNodeMakeArray, OScriptEditablePinNode);
+    static void _bind_methods() { }
 
 protected:
     int _element_count{ 0 };
@@ -52,6 +53,7 @@ public:
 class OScriptNodeArrayGet : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeArrayGet, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     Variant::Type _collection_type{ Variant::ARRAY };
@@ -75,6 +77,7 @@ public:
 class OScriptNodeArraySet : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeArraySet, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     Variant::Type _collection_type{ Variant::ARRAY };
@@ -98,6 +101,7 @@ public:
 class OScriptNodeArrayFind : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeArrayFind, OScriptNode);
+    static void _bind_methods() { }
 
 public:
     //~ Begin OScriptNode Interface
@@ -114,6 +118,7 @@ public:
 class OScriptNodeArrayClear : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeArrayClear, OScriptNode);
+    static void _bind_methods() { }
 
 public:
     //~ Begin OScriptNode Interface
@@ -131,6 +136,7 @@ public:
 class OScriptNodeArrayAppend : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeArrayAppend, OScriptNode);
+    static void _bind_methods() { }
 
 public:
     //~ Begin OScriptNode Interface
@@ -147,6 +153,7 @@ public:
 class OScriptNodeArrayAddElement : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeArrayAddElement, OScriptNode);
+    static void _bind_methods() { }
 
 public:
     //~ Begin OScriptNode Interface
@@ -163,6 +170,7 @@ public:
 class OScriptNodeArrayRemoveElement : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeArrayRemoveElement, OScriptNode);
+    static void _bind_methods() { }
 
 public:
     //~ Begin OScriptNode Interface
@@ -179,6 +187,7 @@ public:
 class OScriptNodeArrayRemoveIndex : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeArrayRemoveIndex, OScriptNode);
+    static void _bind_methods() { }
 
 public:
     //~ Begin OScriptNode Interface

--- a/src/script/nodes/data/compose.h
+++ b/src/script/nodes/data/compose.h
@@ -33,13 +33,13 @@
 class OScriptNodeCompose : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeCompose, OScriptNode);
+    static void _bind_methods();
+
     using TypeMap = HashMap<Variant::Type, Array>;
 
 protected:
     Variant::Type _type;              //! Transient type to pass from creation metadata
     static TypeMap _type_components;  //! Variant types and the respective components
-
-    static void _bind_methods();
 
 public:
     //~ Begin OScriptNode Interface
@@ -63,13 +63,12 @@ public:
 /// Composes a variant using its constructor signatures
 class OScriptNodeComposeFrom : public OScriptNode
 {
-    ORCHESTRATOR_NODE_CLASS(OScriptNodeComposeFrom, OScriptNode)
+    ORCHESTRATOR_NODE_CLASS(OScriptNodeComposeFrom, OScriptNode);
+    static void _bind_methods();
 
 protected:
     Variant::Type _type;                         //! Transient type to pass from creation metadata
     Vector<PropertyInfo> _constructor_args;      //! Transient constructor arguments
-
-    static void _bind_methods();
 
 public:
     //~ Begin OScriptNode Interface

--- a/src/script/nodes/data/decompose.h
+++ b/src/script/nodes/data/decompose.h
@@ -35,14 +35,13 @@ class OScriptNodeDecompose : public OScriptNode
     // todo: this node needs to have its rendering fixed
 
     ORCHESTRATOR_NODE_CLASS(OScriptNodeDecompose, OScriptNode);
+    static void _bind_methods();
 
     using TypeMap = HashMap<Variant::Type, Array>;
 
 protected:
     Variant::Type _type;              //! Transient type to pass from creation metadata
     static TypeMap _type_components;  //! Various types and respective components
-
-    static void _bind_methods();
 
 public:
     //~ Begin OScriptNode Interface

--- a/src/script/nodes/data/dictionary.h
+++ b/src/script/nodes/data/dictionary.h
@@ -23,7 +23,8 @@
 /// Creates a new dictionary
 class OScriptNodeMakeDictionary : public OScriptEditablePinNode
 {
-    ORCHESTRATOR_NODE_CLASS(OScriptNodeMakeDictionary, OScriptEditablePinNode)
+    ORCHESTRATOR_NODE_CLASS(OScriptNodeMakeDictionary, OScriptEditablePinNode);
+    static void _bind_methods() { }
 
 protected:
     int _element_count{ 0 };
@@ -52,6 +53,7 @@ public:
 class OScriptNodeDictionarySet : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeDictionarySet, OScriptNode);
+    static void _bind_methods() { }
 
 public:
     //~ Begin OScriptNode Interface

--- a/src/script/nodes/data/type_cast.h
+++ b/src/script/nodes/data/type_cast.h
@@ -25,6 +25,7 @@ using namespace godot;
 class OScriptNodeTypeCast : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeTypeCast, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     String _target_type{ "Object" };

--- a/src/script/nodes/dialogue/dialogue_choice.h
+++ b/src/script/nodes/dialogue/dialogue_choice.h
@@ -23,7 +23,8 @@
 /// These can be combined into an array and evaluated by a DialogueMessage node.
 class OScriptNodeDialogueChoice : public OScriptNode
 {
-    ORCHESTRATOR_NODE_CLASS(OScriptNodeDialogueChoice, OScriptNode)
+    ORCHESTRATOR_NODE_CLASS(OScriptNodeDialogueChoice, OScriptNode);
+    static void _bind_methods() { }
 
 public:
     //~ Begin OScriptNode Interface

--- a/src/script/nodes/dialogue/dialogue_message.h
+++ b/src/script/nodes/dialogue/dialogue_message.h
@@ -22,7 +22,8 @@
 /// A node that represents a dialogue message that is part of a conversation.
 class OScriptNodeDialogueMessage : public OScriptEditablePinNode
 {
-    ORCHESTRATOR_NODE_CLASS(OScriptNodeDialogueMessage, OScriptEditablePinNode)
+    ORCHESTRATOR_NODE_CLASS(OScriptNodeDialogueMessage, OScriptEditablePinNode);
+    static void _bind_methods() { }
 
 protected:
     int _choices{ 0 };

--- a/src/script/nodes/editable_pin_node.h
+++ b/src/script/nodes/editable_pin_node.h
@@ -24,6 +24,7 @@
 class OScriptEditablePinNode : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptEditablePinNode, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
 

--- a/src/script/nodes/flow_control/branch.h
+++ b/src/script/nodes/flow_control/branch.h
@@ -23,6 +23,7 @@
 class OScriptNodeBranch : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeBranch, OScriptNode);
+    static void _bind_methods() { }
 
 public:
 

--- a/src/script/nodes/flow_control/chance.h
+++ b/src/script/nodes/flow_control/chance.h
@@ -22,6 +22,7 @@
 class OScriptNodeChance : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeChance, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
 

--- a/src/script/nodes/flow_control/delay.h
+++ b/src/script/nodes/flow_control/delay.h
@@ -28,6 +28,7 @@
 class OScriptNodeDelay : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeDelay, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     float _duration{ 1 };  //! Delay duration

--- a/src/script/nodes/flow_control/for.h
+++ b/src/script/nodes/flow_control/for.h
@@ -25,6 +25,7 @@
 class OScriptNodeForLoop : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeForLoop, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     bool _with_break{ false };  //! Whether break is enabled

--- a/src/script/nodes/flow_control/for_each.h
+++ b/src/script/nodes/flow_control/for_each.h
@@ -24,6 +24,7 @@
 class OScriptNodeForEach : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeForEach, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     bool _with_break{ false };  //! Whether break is enabled

--- a/src/script/nodes/flow_control/random.h
+++ b/src/script/nodes/flow_control/random.h
@@ -23,6 +23,7 @@
 class OScriptNodeRandom : public OScriptEditablePinNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeRandom, OScriptEditablePinNode);
+    static void _bind_methods() { }
 
 protected:
     int _possibilities = 1;

--- a/src/script/nodes/flow_control/select.h
+++ b/src/script/nodes/flow_control/select.h
@@ -24,6 +24,7 @@
 class OScriptNodeSelect : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeSelect, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     int _type = 0;

--- a/src/script/nodes/flow_control/sequence.h
+++ b/src/script/nodes/flow_control/sequence.h
@@ -23,6 +23,7 @@
 class OScriptNodeSequence : public OScriptEditablePinNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeSequence, OScriptEditablePinNode);
+    static void _bind_methods() { }
 
 public:
     enum InsertPosition

--- a/src/script/nodes/flow_control/switch.h
+++ b/src/script/nodes/flow_control/switch.h
@@ -24,6 +24,7 @@
 class OScriptNodeSwitch : public OScriptEditablePinNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeSwitch, OScriptEditablePinNode);
+    static void _bind_methods() { }
 
 protected:
     int _cases{ 0 };     //! Transient case count
@@ -58,6 +59,7 @@ public:
 class OScriptNodeSwitchEditablePin : public OScriptEditablePinNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeSwitchEditablePin, OScriptEditablePinNode);
+    static void _bind_methods() { }
 
 protected:
     PackedStringArray _pin_names;
@@ -97,6 +99,7 @@ public:
 class OScriptNodeSwitchString : public OScriptNodeSwitchEditablePin
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeSwitchString, OScriptNodeSwitchEditablePin);
+    static void _bind_methods() { }
 
 protected:
     //~ Begin OScriptNodeSwitchEditablePin Interface
@@ -117,6 +120,7 @@ public:
 class OScriptNodeSwitchInteger : public OScriptNodeSwitchEditablePin
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeSwitchInteger, OScriptNodeSwitchEditablePin);
+    static void _bind_methods() { }
 
 protected:
     int _start_index{ 0 };
@@ -147,6 +151,7 @@ public:
 class OScriptNodeSwitchEnum : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeSwitchEnum, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     String _enum_name; //! Transient enum name

--- a/src/script/nodes/flow_control/while.h
+++ b/src/script/nodes/flow_control/while.h
@@ -23,6 +23,7 @@
 class OScriptNodeWhile : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeWhile, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     bool _condition = false;

--- a/src/script/nodes/functions/call_function.h
+++ b/src/script/nodes/functions/call_function.h
@@ -48,7 +48,6 @@ struct OScriptFunctionReference
 class OScriptNodeCallFunction : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeCallFunction, OScriptNode);
-
     static void _bind_methods();
 
 public:

--- a/src/script/nodes/functions/event.h
+++ b/src/script/nodes/functions/event.h
@@ -29,6 +29,7 @@ using namespace godot;
 class OScriptNodeEvent : public OScriptNodeFunctionEntry
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeEvent, OScriptNodeFunctionEntry);
+    static void _bind_methods() { }
 
 protected:
 

--- a/src/script/nodes/functions/function_entry.h
+++ b/src/script/nodes/functions/function_entry.h
@@ -27,6 +27,7 @@
 class OScriptNodeFunctionEntry : public OScriptNodeFunctionTerminator
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeFunctionEntry, OScriptNodeFunctionTerminator);
+    static void _bind_methods() { }
 
 protected:
     virtual bool _is_user_defined() const { return true; }

--- a/src/script/nodes/functions/function_result.h
+++ b/src/script/nodes/functions/function_result.h
@@ -35,6 +35,7 @@
 class OScriptNodeFunctionResult : public OScriptNodeFunctionTerminator
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeFunctionResult, OScriptNodeFunctionTerminator);
+    static void _bind_methods() { }
 
 public:
     //~ Begin OScriptNode Interface

--- a/src/script/nodes/functions/function_terminator.h
+++ b/src/script/nodes/functions/function_terminator.h
@@ -23,6 +23,7 @@
 class OScriptNodeFunctionTerminator : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeFunctionTerminator, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     Guid _guid;                      //! Function guid

--- a/src/script/nodes/input/input_action.h
+++ b/src/script/nodes/input/input_action.h
@@ -23,6 +23,7 @@
 class OScriptNodeInputAction : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeInputAction, OScriptNode);
+    static void _bind_methods();
 
 public:
     // Various action modes
@@ -45,8 +46,6 @@ protected:
 
     PackedStringArray _get_action_names() const;
     String _get_mode() const;
-
-    static void _bind_methods();
 
 public:
 

--- a/src/script/nodes/math/operator_node.h
+++ b/src/script/nodes/math/operator_node.h
@@ -24,7 +24,6 @@
 class OScriptNodeOperator : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeOperator, OScriptNode);
-
     static void _bind_methods();
 
 protected:

--- a/src/script/nodes/memory/memory.h
+++ b/src/script/nodes/memory/memory.h
@@ -22,7 +22,8 @@
 /// Creates a new instance of a Godot class
 class OScriptNodeNew : public OScriptNode
 {
-    ORCHESTRATOR_NODE_CLASS(OScriptNodeNew, OScriptNode)
+    ORCHESTRATOR_NODE_CLASS(OScriptNodeNew, OScriptNode);
+    static void _bind_methods();
 
 protected:
     String _class_name;
@@ -32,8 +33,6 @@ protected:
     bool _get(const StringName& p_name, Variant& r_value) const;
     bool _set(const StringName& p_name, const Variant& p_value);
     //~ End Wrapped Interface
-
-    static void _bind_methods();
 
 public:
     //~ Begin OScriptNode Interface
@@ -54,8 +53,7 @@ public:
 /// Destroys an instance of a Godot class
 class OScriptNodeFree : public OScriptNode
 {
-    ORCHESTRATOR_NODE_CLASS(OScriptNodeFree, OScriptNode)
-protected:
+    ORCHESTRATOR_NODE_CLASS(OScriptNodeFree, OScriptNode);
     static void _bind_methods();
 
 public:

--- a/src/script/nodes/properties/property.h
+++ b/src/script/nodes/properties/property.h
@@ -35,6 +35,7 @@ using namespace godot;
 class OScriptNodeProperty : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeProperty, OScriptNode);
+    static void _bind_methods();
 
 public:
     enum CallMode : uint32_t
@@ -57,8 +58,6 @@ protected:
     bool _get(const StringName& p_name, Variant& r_value) const;
     bool _set(const StringName& p_name, const Variant& p_value);
     //~ End Wrapped Interface
-
-    static void _bind_methods();
 
 public:
     OScriptNodeProperty();

--- a/src/script/nodes/properties/property_get.h
+++ b/src/script/nodes/properties/property_get.h
@@ -23,6 +23,7 @@
 class OScriptNodePropertyGet : public OScriptNodeProperty
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodePropertyGet, OScriptNodeProperty);
+    static void _bind_methods() { }
 
 public:
     //~ Begin OScriptNode Interface

--- a/src/script/nodes/properties/property_set.h
+++ b/src/script/nodes/properties/property_set.h
@@ -23,6 +23,7 @@
 class OScriptNodePropertySet : public OScriptNodeProperty
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodePropertySet, OScriptNodeProperty);
+    static void _bind_methods() { }
 
 public:
     //~ Begin OScriptNode Interface

--- a/src/script/nodes/resources/preload.h
+++ b/src/script/nodes/resources/preload.h
@@ -23,6 +23,7 @@
 class OScriptNodePreload : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodePreload, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     Ref<Resource> _resource;  //! The loaded resource

--- a/src/script/nodes/resources/resource_path.h
+++ b/src/script/nodes/resources/resource_path.h
@@ -23,6 +23,7 @@
 class OScriptNodeResourcePath : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeResourcePath, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     String _path;  //! The resource path

--- a/src/script/nodes/scene/scene_node.h
+++ b/src/script/nodes/scene/scene_node.h
@@ -23,6 +23,7 @@
 class OScriptNodeSceneNode : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeSceneNode, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     NodePath _node_path;

--- a/src/script/nodes/scene/scene_tree.h
+++ b/src/script/nodes/scene/scene_tree.h
@@ -23,6 +23,7 @@
 class OScriptNodeSceneTree : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeSceneTree, OScriptNode);
+    static void _bind_methods() { }
 
 public:
     //~ Begin OScriptNode Interface

--- a/src/script/nodes/signals/await_signal.h
+++ b/src/script/nodes/signals/await_signal.h
@@ -31,6 +31,7 @@
 class OScriptNodeAwaitSignal : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeAwaitSignal, OScriptNode);
+    static void _bind_methods() { }
 
 public:
     //~ Begin OScriptNode Interface

--- a/src/script/nodes/signals/emit_member_signal.h
+++ b/src/script/nodes/signals/emit_member_signal.h
@@ -27,6 +27,7 @@
 class OScriptNodeEmitMemberSignal : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeEmitMemberSignal, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     String _target_class;   //! Signal target class name reference

--- a/src/script/nodes/signals/emit_signal.h
+++ b/src/script/nodes/signals/emit_signal.h
@@ -32,6 +32,7 @@
 class OScriptNodeEmitSignal : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeEmitSignal, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     Ref<OScriptSignal> _signal;     //! Signal reference

--- a/src/script/nodes/utilities/autoload.h
+++ b/src/script/nodes/utilities/autoload.h
@@ -23,6 +23,7 @@
 class OScriptNodeAutoload : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeAutoload, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     String _autoload;  //! Name of the autoload

--- a/src/script/nodes/utilities/comment.h
+++ b/src/script/nodes/utilities/comment.h
@@ -23,6 +23,7 @@
 class OScriptNodeComment : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeComment, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     String _comments;

--- a/src/script/nodes/utilities/engine_singleton.h
+++ b/src/script/nodes/utilities/engine_singleton.h
@@ -23,6 +23,7 @@
 class OScriptNodeEngineSingleton : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeEngineSingleton, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     String _singleton{ "Engine" };  //! Name of the singleton

--- a/src/script/nodes/utilities/print_string.h
+++ b/src/script/nodes/utilities/print_string.h
@@ -31,6 +31,7 @@ using namespace godot;
 class OScriptNodePrintString : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodePrintString, OScriptNode);
+    static void _bind_methods() { }
 
 public:
 

--- a/src/script/nodes/utilities/self.h
+++ b/src/script/nodes/utilities/self.h
@@ -24,6 +24,7 @@
 class OScriptNodeSelf : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeSelf, OScriptNode);
+    static void _bind_methods() { }
 
     void _on_script_changed();
 

--- a/src/script/nodes/variables/local_variable.h
+++ b/src/script/nodes/variables/local_variable.h
@@ -22,6 +22,7 @@
 class OScriptNodeLocalVariable : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeLocalVariable, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     Guid _guid;           //! Uniquely identifies this variable from any other.
@@ -55,6 +56,7 @@ public:
 class OScriptNodeAssignLocalVariable : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeAssignLocalVariable, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     Variant::Type _type{ Variant::NIL }; //! Transient type used to identify pin type

--- a/src/script/nodes/variables/variable.h
+++ b/src/script/nodes/variables/variable.h
@@ -23,6 +23,7 @@
 class OScriptNodeVariable : public OScriptNode
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeVariable, OScriptNode);
+    static void _bind_methods() { }
 
 protected:
     StringName _variable_name;       //! Variable name reference

--- a/src/script/nodes/variables/variable_get.h
+++ b/src/script/nodes/variables/variable_get.h
@@ -23,6 +23,7 @@
 class OScriptNodeVariableGet : public OScriptNodeVariable
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeVariableGet, OScriptNodeVariable);
+    static void _bind_methods() { }
 
 public:
     //~ Begin OScriptNodeVariable Interface

--- a/src/script/nodes/variables/variable_set.h
+++ b/src/script/nodes/variables/variable_set.h
@@ -23,6 +23,7 @@
 class OScriptNodeVariableSet : public OScriptNodeVariable
 {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeVariableSet, OScriptNodeVariable);
+    static void _bind_methods() { }
 
 public:
     //~ Begin OScriptNodeVariable Interface


### PR DESCRIPTION
* Adds missing `_bind_methods()` method for several nodes (compile-time check added in Godot 4.3)
* Fixes several macro usages of `ORCHESTRATOR_NODE_CLASS` to be followed with a `;`
* Moves all `_bind_methods()` to the private scope