### PR TITLE
Add a boolean setting to show the 'arrange' button in the UI.

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -150,6 +150,7 @@ void OrchestratorSettings::_register_settings()
     _settings.emplace_back(BOOL_SETTING("ui/graph/disconnect_control_flow_when_dragged", true));
     _settings.emplace_back(BOOL_SETTING("ui/graph/show_autowire_selection_dialog", true));
     _settings.emplace_back(BOOL_SETTING("ui/graph/show_minimap", false));
+    _settings.emplace_back(BOOL_SETTING("ui/graph/show_arrange_button", false));
     _settings.emplace_back(BOOL_SETTING("ui/graph/show_overlay_action_tooltips", true));
     _settings.emplace_back(COLOR_NO_ALPHA_SETTING("ui/graph/knot_selected_color", Color(0.68f, 0.44f, 0.09f)));
 

--- a/src/editor/graph/graph_edit.cpp
+++ b/src/editor/graph/graph_edit.cpp
@@ -104,8 +104,8 @@ OrchestratorGraphEdit::OrchestratorGraphEdit(OrchestratorPlugin* p_plugin, const
 
     set_name(p_graph->get_graph_name());
     set_minimap_enabled(OrchestratorSettings::get_singleton()->get_setting("ui/graph/show_minimap", false));
+    set_show_arrange_button(OrchestratorSettings::get_singleton()->get_setting("ui/graph/show_arrange_button", false));
     set_right_disconnects(true);
-    set_show_arrange_button(false);
 
     _plugin = p_plugin;
     _script_graph = p_graph;
@@ -1661,6 +1661,7 @@ void OrchestratorGraphEdit::_on_project_settings_changed()
         bool node_resizable = os->get_setting("ui/nodes/resizable_by_default", false);
 
         set_minimap_enabled(os->get_setting("ui/graph/show_minimap", false));
+        set_show_arrange_button(os->get_setting("ui/graph/show_arrange_button", false));
 
         for_each_graph_node([&](OrchestratorGraphNode* node) {
             node->show_icons(show_icons);


### PR DESCRIPTION
I am trying to restore auto-arrange. Do you remember why it was removed?

https://github.com/Vahera/godot-orchestrator/assets/32321/68c54a55-b2e0-4042-9144-f0d063e86d99

I noticed that auto-arrange undo and redo is bugged - Will fill a bug report.

Also frames are not interacting.

I might be able to get these changed patched upstream.
