### PR TITLE
GH-492 Correctly resolve signal argument types

### DIFF
--- a/src/editor/component_panels/functions_panel.h
+++ b/src/editor/component_panels/functions_panel.h
@@ -28,7 +28,8 @@ class OrchestratorScriptFunctionsComponentPanel : public OrchestratorScriptCompo
     {
         CM_OPEN_FUNCTION_GRAPH,
         CM_RENAME_FUNCTION,
-        CM_REMOVE_FUNCTION
+        CM_REMOVE_FUNCTION,
+        CM_DISCONNECT_SLOT
     };
 
     Button* _override_button{ nullptr };
@@ -54,6 +55,7 @@ protected:
 
     //~ Begin Signal handlers
     void _show_function_graph(TreeItem* p_item);
+    void _disconnect_slot(TreeItem* p_item);
     //~ End Signal handlers
 
     /// Default constructor

--- a/src/editor/component_panels/graphs_panel.h
+++ b/src/editor/component_panels/graphs_panel.h
@@ -30,7 +30,8 @@ class OrchestratorScriptGraphsComponentPanel : public OrchestratorScriptComponen
         CM_RENAME_GRAPH,
         CM_REMOVE_GRAPH,
         CM_FOCUS_FUNCTION,
-        CM_REMOVE_FUNCTION
+        CM_REMOVE_FUNCTION,
+        CM_DISCONNECT_SLOT
     };
 
 protected:
@@ -65,6 +66,9 @@ protected:
     /// Notifies the script view that a graph function was removed.
     /// @param p_item the graph function item, should not be null
     void _remove_graph_function(TreeItem* p_item);
+
+    /// Handles disconnecting a signal slot function from the signal
+    void _disconnect_slot(TreeItem* p_item);
 
     /// Default constructor
     OrchestratorScriptGraphsComponentPanel() = default;

--- a/src/editor/editor_panel.h
+++ b/src/editor/editor_panel.h
@@ -180,6 +180,7 @@ protected:
     void _file_removed(const String& p_file_name);
     void _file_moved(const String& p_old_file_name, const String& p_new_file_name);
     void _folder_removed(const String& p_folder_name);
+    void _add_script_function(Object* p_object, const String& p_function_name, const PackedStringArray& p_args);
 
     #if GODOT_VERSION >= 0x040300
     void _goto_script_line(const Ref<Script>& p_script, int p_line);

--- a/src/editor/editor_viewport.h
+++ b/src/editor/editor_viewport.h
@@ -184,6 +184,12 @@ public:
     /// @param p_node_id the node ID
     void goto_node(int p_node_id);
 
+    /// Add a script function
+    /// @param p_object the object
+    /// @param p_function_name the function name
+    /// @param p_args the arguments for the function
+    virtual void add_script_function(Object* p_object, const String& p_function_name, const PackedStringArray& p_args) { }
+
     /// Notifies this viewport that the scene tab has changed
     void notify_scene_tab_changed();
 

--- a/src/editor/script_editor_viewport.h
+++ b/src/editor/script_editor_viewport.h
@@ -49,12 +49,6 @@ protected:
     void _graph_opened(OrchestratorGraphEdit* p_graph) override;
     //~ End OrchestratorEditorViewport Interface
 
-    /// Adds a signal handler callback to this script
-    /// @param p_object the object to be found
-    /// @param p_function_name the function name to be created
-    /// @param p_args the function arguments, if any
-    void _add_callback(Object* p_object, const String& p_function_name, const PackedStringArray& p_args);
-
     /// Creates a new function in the script
     /// @param p_name the function name
     /// @param p_has_return whether function has a return node
@@ -99,6 +93,10 @@ protected:
     OrchestratorScriptEditorViewport() = default;
 
 public:
+    //~ Begin OrchestratorEditorViewport Interface
+    void add_script_function(Object* p_object, const String& p_function_name, const PackedStringArray& p_args) override;
+    //~ End OrchestratorEditorViewport Interface
+
     /// Constructor
     /// @param p_script the orchestration script
     explicit OrchestratorScriptEditorViewport(const Ref<OScript>& p_script);

--- a/src/script/language.cpp
+++ b/src/script/language.cpp
@@ -277,6 +277,13 @@ String OScriptLanguage::_make_function(const String& p_class_name, const String&
     return {};
 }
 
+#if GODOT_VERSION >= 0x040300
+bool OScriptLanguage::_can_make_function() const
+{
+    return true;
+}
+#endif
+
 TypedArray<Dictionary> OScriptLanguage::_get_public_functions() const
 {
     // Returns an array of MethodInfo for the language.

--- a/src/script/language.h
+++ b/src/script/language.h
@@ -157,6 +157,9 @@ public:
     int32_t _find_function(const String& p_function_name, const String& p_code) const override;
     String _make_function(const String& p_class_name, const String& p_function_name,
                           const PackedStringArray& p_function_args) const override;
+    #if GODOT_VERSION >= 0x040300
+    bool _can_make_function() const override;
+    #endif
     TypedArray<Dictionary> _get_public_functions() const override;
     Dictionary _get_public_constants() const override;
     TypedArray<Dictionary> _get_public_annotations() const override;


### PR DESCRIPTION
Fixes #492 

This change aims to improve the creation of signal slot function handlers by ensuring that argument types are resolved as appropriate class types rather than always treating them as explicit `Variant` or basic types. In addition, this fix includes a few enhancements.

### Add signals to not yet opened Orchestrations

In prior releases, the `Orchestration` must be opened in the Orchestrator tab before a signal slot function can be added to the script.  If this was not the case, the signal would get registered in the scene but no function would be created in the script to handle the signal when fired.  

The callback handler method has been relocated to the main editor panel widget, which is always active in the Editor.  This means that if you create a signal slot handler function and pick a node that has an Orchestration on it, the callback will be handled by Orchestrator even if the script is not yet opened.  If the script isn't opened, it will be opened.  If the Orchestrator tab is not the current main focus in the Editor, it will be made active as well.  This should help with overall workflow.

### Disconnecting slot functions

A slot function, one which has a green icon to the right of its name, can now be disconnected from the signal by simply right clicking the Graph Function or User-defined Function in the component view and selecting `Disconnect`.