### PR TITLE
GH-595 Improve initial rendering of variable type selection

### DIFF
--- a/src/editor/inspector/property_type_button_property.cpp
+++ b/src/editor/inspector/property_type_button_property.cpp
@@ -21,7 +21,7 @@
 
 void OrchestratorEditorPropertyVariableClassification::_property_selected()
 {
-    _dialog->popup_create(true, true, get_edited_object()->get(get_edited_property()), get_edited_property());
+    _dialog->popup_create(true, false, get_edited_object()->get(get_edited_property()), get_edited_property());
 }
 
 void OrchestratorEditorPropertyVariableClassification::_search_selected()
@@ -61,7 +61,7 @@ void OrchestratorEditorPropertyVariableClassification::_update_property()
 
 void OrchestratorEditorPropertyVariableClassification::edit()
 {
-    _dialog->popup_create(true, true, get_edited_object()->get(get_edited_property()), get_edited_property());
+    _dialog->popup_create(true, false, get_edited_object()->get(get_edited_property()), get_edited_property());
 }
 
 void OrchestratorEditorPropertyVariableClassification::setup(const String& p_base_type, const String& p_selected_type)

--- a/src/editor/search/search_dialog.cpp
+++ b/src/editor/search/search_dialog.cpp
@@ -329,6 +329,12 @@ void OrchestratorEditorSearchDialog::_set_search_item_collapse_state(TreeItem* p
     }
     else if (p_item->get_parent())
     {
+        if (_search_box->get_text().is_empty() && _should_collapse_on_empty_search())
+        {
+            p_item->set_collapsed(true);
+            return;
+        }
+
         bool should_collapse = _get_search_item_collapse_suggestion(p_item);
 
         Ref<EditorSettings> settings = OrchestratorPlugin::get_singleton()->get_editor_interface()->get_editor_settings();
@@ -452,6 +458,7 @@ void OrchestratorEditorSearchDialog::_update_search()
 
     if (_search_box->get_text().is_empty())
     {
+        _favorite->set_pressed_no_signal(false);
         _search_options->scroll_to_item(_search_options->get_root());
         _search_options->deselect_all();
     }

--- a/src/editor/search/search_dialog.h
+++ b/src/editor/search/search_dialog.h
@@ -155,6 +155,10 @@ protected:
     /// @param p_focus whether to focus to the search box
     virtual void _update_search_box(bool p_clear, bool p_replace, const String& p_text, bool p_focus);
 
+    /// Whether the dialog should collapse nodes on empty search terms
+    /// @returns whether to collapse non-root tree nodes when search box is empty, defaults to false.
+    virtual bool _should_collapse_on_empty_search() const { return false; }
+
     /// Sets the search item's collapse state
     /// @param p_item the tree item
     virtual void _set_search_item_collapse_state(TreeItem* p_item);
@@ -210,7 +214,6 @@ protected:
     void _select_item(TreeItem* p_item, bool p_center_on_item);
 
 public:
-
     /// Opens the dialog
     /// @param p_dont_clear whether the dialog should clear the search field
     /// @param p_replace_mode whether the dialog should replace the current type

--- a/src/editor/select_type_dialog.cpp
+++ b/src/editor/select_type_dialog.cpp
@@ -76,6 +76,11 @@ bool OrchestratorSelectTypeSearchDialog::_is_preferred(const String& p_type) con
     return OrchestratorEditorSearchDialog::_is_preferred(p_type);
 }
 
+bool OrchestratorSelectTypeSearchDialog::_should_collapse_on_empty_search() const
+{
+    return _filters->get_selected_id() == FT_ALL_TYPES;
+}
+
 bool OrchestratorSelectTypeSearchDialog::_get_search_item_collapse_suggestion(TreeItem* p_item) const
 {
     if (p_item->get_parent())
@@ -98,6 +103,28 @@ Vector<Ref<OrchestratorEditorSearchDialog::SearchItem>> OrchestratorSelectTypeSe
     root->collapsed = false; // Root always expanded
     root->set_meta("can_instantiate", false);
     items.push_back(root);
+
+    Ref<SearchItem> global_enums(memnew(SearchItem));
+    global_enums->path = "Types/Global_Enums";
+    global_enums->name = "Global Enums";
+    global_enums->text = "Global Enums";
+    global_enums->selectable = false;
+    global_enums->collapsed = false;
+    global_enums->icon = SceneUtils::get_editor_icon("Enum");
+    global_enums->set_meta("can_instantiate", false);
+    global_enums->parent = root;
+    items.push_back(global_enums);
+
+    Ref<SearchItem> global_bitfields(memnew(SearchItem));
+    global_bitfields->path = "Types/Global_Bitfields";
+    global_bitfields->name = "Global Bitfields";
+    global_bitfields->text = "Global Bitfields";
+    global_bitfields->selectable = false;
+    global_bitfields->collapsed = false;
+    global_bitfields->icon = SceneUtils::get_editor_icon("Enum");
+    global_bitfields->set_meta("can_instantiate", false);
+    global_bitfields->parent = root;
+    items.push_back(global_bitfields);
 
     // Basic Types
     for (int i = 0; i < Variant::VARIANT_MAX; i++)
@@ -149,12 +176,12 @@ Vector<Ref<OrchestratorEditorSearchDialog::SearchItem>> OrchestratorSelectTypeSe
         const EnumInfo& ei = ExtensionDB::get_global_enum(enum_name);
 
         Ref<SearchItem> item(memnew(SearchItem));
-        item->path = vformat("Types/%s", enum_name);
+        item->path = vformat("Types/%s/%s", ei.is_bitfield ? "Global_Bitfields" : "Global_Enums", enum_name);
         item->name = vformat("%s:%s", ei.is_bitfield ? "bitfield" : "enum", enum_name);
         item->text = enum_name;
         item->icon = SceneUtils::get_editor_icon("Enum");
         item->selectable = true;
-        item->parent = root;
+        item->parent = ei.is_bitfield ? global_bitfields : global_enums;
         items.push_back(item);
     }
 

--- a/src/editor/select_type_dialog.h
+++ b/src/editor/select_type_dialog.h
@@ -54,6 +54,7 @@ class OrchestratorSelectTypeSearchDialog : public OrchestratorEditorSearchDialog
 protected:
     //~ Begin OrchestratorEditorSearchDialog Interface
     bool _is_preferred(const String& p_type) const override;
+    bool _should_collapse_on_empty_search() const override;
     bool _get_search_item_collapse_suggestion(TreeItem* p_item) const override;
     void _update_help(const Ref<SearchItem>& p_item) override;
     Vector<Ref<SearchItem>> _get_search_items() override;


### PR DESCRIPTION
Fixes #595 

- All search items (excluding root item) are collapsed when the search box is empty.
- There is no initial search text in the search box.
- All global enums and bitfields have been relocated under new `Types/Global Enum` and `Types/Global Bitfield` categories.
- Fixes clearing search box to reset favorite button press state.