### PR TITLE
GH-593 Fix collapse to function bugs

### DIFF
--- a/src/script/function.cpp
+++ b/src/script/function.cpp
@@ -245,6 +245,15 @@ void OScriptFunction::set_argument_type(size_t p_index, Variant::Type p_type)
     }
 }
 
+void OScriptFunction::set_argument(size_t p_index, const PropertyInfo& p_property)
+{
+    if (_method.arguments.size() > p_index && _user_defined)
+    {
+        _method.arguments[p_index] = p_property;
+        emit_changed();
+    }
+}
+
 void OScriptFunction::set_arguments(const TypedArray<Dictionary>& p_arguments)
 {
     if (_user_defined)

--- a/src/script/function.h
+++ b/src/script/function.h
@@ -153,6 +153,11 @@ public:
     /// @param p_type the new argument type
     void set_argument_type(size_t p_index, Variant::Type p_type);
 
+    /// Sets the argument property details
+    /// @param p_index the argument index
+    /// @param p_property the argument details
+    void set_argument(size_t p_index, const PropertyInfo& p_property);
+
     /// Sets the arguments for this function
     /// @param p_arguments the argument list
     void set_arguments(const TypedArray<Dictionary>& p_arguments);

--- a/src/script/nodes/functions/call_function.cpp
+++ b/src/script/nodes/functions/call_function.cpp
@@ -313,7 +313,7 @@ void OScriptNodeCallFunction::_create_pins_for_method(const MethodInfo& p_method
         if (pin.is_valid())
         {
             const String arg_class_name = pin->get_property_info().class_name;
-            if (!arg_class_name.is_empty())
+            if (!arg_class_name.is_empty() && _use_argument_class_name())
             {
                 if (arg_class_name.contains("."))
                     pin->set_label(arg_class_name.substr(arg_class_name.find(".") + 1));

--- a/src/script/nodes/functions/call_function.h
+++ b/src/script/nodes/functions/call_function.h
@@ -87,6 +87,10 @@ protected:
     /// @return true if the MethodInfo is saved as part of the node's data, false if it isn't
     virtual bool _is_method_info_serialized() const { return true; }
 
+    /// Specifies whether arguments that are class types should be labeled by class names
+    /// @return true to use class names, return false to use pin label or name
+    virtual bool _use_argument_class_name() const { return true; }
+
     /// Return whether the return value pin should be labeled
     /// @param p_pin the return value pin
     /// @return true if the pin is labeled, false otherwise

--- a/src/script/nodes/functions/call_script_function.h
+++ b/src/script/nodes/functions/call_script_function.h
@@ -36,6 +36,7 @@ protected:
     //~ Begin OScriptNodeCallFunction Interface
     bool _is_method_info_serialized() const override { return false; }
     bool _has_execution_pins(const MethodInfo& p_method) const override { return true; }
+    bool _use_argument_class_name() const override { return false; }
     MethodInfo get_method_info() override { return _function->get_method_info(); }
     int get_argument_count() const override { return (int) _function->get_argument_count(); }
     //~ End OScriptNodeCallFunction Interface


### PR DESCRIPTION
Fixes #593 

- Pins should retain type
- Multiple pins should not have the same name
- Optional return node
- Script function call nodes use argument namse