### PR TITLE
GH-610 Add in-editor script node documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ INCLUDE(generate-license)
 INCLUDE(generate-version)
 INCLUDE(generate-donors)
 INCLUDE(godot-extension-db-generator)
+INCLUDE(godot-docs-generator)
 
 # Generation steps
 GENERATE_LICENSE()
@@ -66,6 +67,7 @@ GENERATE_VERSION()
 GENERATE_AUTHORS()
 GENERATE_DONORS()
 GENERATE_GODOT_EXTENSION_DB()
+GENERATE_GODOT_DOCUMENTATION()
 
 # MacOS universal binary support
 IF (APPLE)
@@ -87,6 +89,8 @@ FILE(GLOB_RECURSE gdext_sources
         CONFIGURE_DEPENDS
         "${CMAKE_CURRENT_SOURCE_DIR}/src/*.[hc]"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/*.[hc]pp"
+        # Includes the generated doc data from /doc_classes
+        "${CMAKE_BINARY_DIR}/_generated/*.cpp"
 )
 
 # GDExtension library

--- a/cmake/generate_godot_docs.py
+++ b/cmake/generate_godot_docs.py
@@ -1,0 +1,72 @@
+## This file is part of the Godot Orchestrator project.
+##
+## Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##		http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+import os, sys, platform
+
+def make_doc_source(target, source):
+    import zlib
+
+    dst = str(target[0])
+    g = open(dst, "w", encoding="utf-8")
+    buf = ""
+    docbegin = ""
+    docend = ""
+    for src in source:
+        src_path = str(src)
+        if not src_path.endswith(".xml"):
+            continue
+        with open(src_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        buf += content
+
+    buf = (docbegin + buf + docend).encode("utf-8")
+    decomp_size = len(buf)
+
+    # Use maximum zlib compression level to further reduce file size
+    # (at the cost of initial build times).
+    buf = zlib.compress(buf, zlib.Z_BEST_COMPRESSION)
+
+    g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
+    g.write("\n")
+    g.write("#include <godot_cpp/godot.hpp>\n")
+    g.write("\n")
+
+    g.write('static const char *_doc_data_hash = "' + str(hash(buf)) + '";\n')
+    g.write("static const int _doc_data_uncompressed_size = " + str(decomp_size) + ";\n")
+    g.write("static const int _doc_data_compressed_size = " + str(len(buf)) + ";\n")
+    g.write("static const unsigned char _doc_data_compressed[] = {\n")
+    for i in range(len(buf)):
+        g.write("\t" + str(buf[i]) + ",\n")
+    g.write("};\n")
+    g.write("\n")
+
+    g.write(
+        "static godot::internal::DocDataRegistration _doc_data_registration(_doc_data_hash, _doc_data_uncompressed_size, _doc_data_compressed_size, _doc_data_compressed);\n"
+    )
+    g.write("\n")
+
+    g.close()
+
+def main():
+    if len(sys.argv) > 2:
+        target_str = sys.argv[1]
+        target_list = target_str.split(",")
+        source_str = sys.argv[2]
+        source_list = source_str.split(",")
+        make_doc_source(target_list, source_list)
+
+if __name__ == "__main__":
+    main()

--- a/cmake/godot-docs-generator.cmake
+++ b/cmake/godot-docs-generator.cmake
@@ -1,0 +1,30 @@
+## This file is part of the Godot Orchestrator project.
+##
+## Copyright (c) 2023-present Vahera Studios LLC and its contributors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##		http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+FUNCTION( GENERATE_GODOT_DOCUMENTATION )
+    # Grab all documentation XML files
+    FILE(GLOB XML_FILES "${CMAKE_CURRENT_SOURCE_DIR}/doc_classes/*.xml")
+    STRING(JOIN "," XML_FILES_STR ${XML_FILES})
+    # Generate the target file
+    SET(DOC_DATA_CPP_FILE "${CMAKE_BINARY_DIR}/_generated/doc_data.cpp")
+    STRING(JOIN "," DOC_DATA_CPP_STR ${DOC_DATA_CPP_FILE})
+    # Run python to generate the doc_data.cpp file
+    EXECUTE_PROCESS(
+            COMMAND cmd /c py ${CMAKE_CURRENT_SOURCE_DIR}/cmake/generate_godot_docs.py ${DOC_DATA_CPP_STR} ${XML_FILES_STR}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+ENDFUNCTION()

--- a/doc_classes/OScript.xml
+++ b/doc_classes/OScript.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScript" inherits="ScriptExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        A script implementating the Orchestration visual script language.
+    </brief_description>
+    <description>
+        An [OScript] represents an orchestration, a graph-based, visual script language that works similarly to [GDScript].
+    </description>
+</class>

--- a/doc_classes/OScriptEditablePinNode.xml
+++ b/doc_classes/OScriptEditablePinNode.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptEditablePinNode" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        An abstract node that enables an Orchestrator node to have editable input or output pins.
+    </brief_description>
+    <description>
+        Most Orchestrator nodes have a finite number of defined input and output pins based on what the node does. There are, however, use cases where it's helpful for a node to provide an unbounded number of input or output arguments.
+        For example, Godot provides a utility function called [method str].  This is a variable-argument method, meaning that the method accepts zero or more arguments to create a [code]String[/code] output.
+        [codeblock]
+        func _my_function():
+            var data1 = str("Hello", " ", "World")
+            var data2 = str("Hello", " ", 12345)
+        [/codeblock]
+        When a [OScriptNodeCallFunction] node is added to call [method str] in an Orchestration, you can add any number of input arguments due to the behavior provided by this node.
+        [b]Adding Inputs/Outputs:[/b][br]Use the [code]+[/code] button in the bottom-right corner to add new input/outputs.
+        [b]Removing Inputs/Outputs:[/b][br]Right-click the input/output pin's name and select [code]Remove Pin[/code] from the context-menu.
+    </description>
+</class>

--- a/doc_classes/OScriptNode.xml
+++ b/doc_classes/OScriptNode.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNode" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        The base class for all Orchestrator nodes.
+    </brief_description>
+</class>

--- a/doc_classes/OScriptNodeArrayAddElement.xml
+++ b/doc_classes/OScriptNodeArrayAddElement.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeArrayAddElement" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Adds an element to an [Array].
+    </brief_description>
+    <description>
+        This node takes the [param target] pin [Array] and appends the specified [param element] pin item to the end of the array. The output [param index] pin returns the position in the [Array] where the item was added.
+    </description>
+</class>

--- a/doc_classes/OScriptNodeArrayAppend.xml
+++ b/doc_classes/OScriptNodeArrayAppend.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeArrayAppend" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Appends one [Array] into another [Array].
+    </brief_description>
+    <description>
+        This node takes the [param target] [Array] and appends the contents of the [param source] [Array], returning the modified [param target] [Array] as the output.
+        [b]NOTE:[/b] The [param source] [Array] is not modified by this node, only the [param target] [Array].
+    </description>
+</class>

--- a/doc_classes/OScriptNodeArrayClear.xml
+++ b/doc_classes/OScriptNodeArrayClear.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeArrayClear" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Clears the contents of the given array.
+    </brief_description>
+    <description>
+        Removes all elements from the provided [Array].
+        The [param array] pin provides the [Array] instance that should be cleared. Once the array's elements have been cleared, the same [Array] instance is returned in the output [param array] pin.
+    </description>
+</class>

--- a/doc_classes/OScriptNodeArrayFind.xml
+++ b/doc_classes/OScriptNodeArrayFind.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeArrayFind" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Finds the specified element within the given array, returning its position.
+    </brief_description>
+    <description>
+        This node iterates each element in an [Array], locating the provided element. If it exists, the node returns the position within the [Array]. If the element does not exist, the node returns [code]-1[/code].
+        The [param array] pin specifies the [Array] that will be searched. The [param item] pin specifies the element item to find within the given array.
+        The output [param array] pin returns the input [Array] should additional operations need to be performed on the array. The output [param index] pin returns the index where the [param item] was found, or [code]-1[/code] if it was not found.
+    </description>
+</class>

--- a/doc_classes/OScriptNodeArrayGet.xml
+++ b/doc_classes/OScriptNodeArrayGet.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeArrayGet" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Get an element in an array by its index position.
+    </brief_description>
+    <description>
+        This node reads an element from a given [Array] at the specified position.
+        The [param Array] pin specifies the [Array] that will be read by this node. The [param index] pin specifies the position where the element will be read from. If the specified [param index] is out of bounds, meaning it is negative or greater-than or equal-to the size of the [Array], an error occurs.
+        The output [param element] pin provides the array element at the specified position as a [Variant].
+        [b]NOTE:[/b] An [OScriptNodeTypeCast] node can be used to access context-specific methods or properties on the element.
+    </description>
+</class>

--- a/doc_classes/OScriptNodeArrayRemoveElement.xml
+++ b/doc_classes/OScriptNodeArrayRemoveElement.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeArrayRemoveElement" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Removes an element from an [Array].
+    </brief_description>
+    <description>
+        This node attempts to remove the element specified by the [param element] pin from the [Array] specified by the [param target] pin. The [Array] is returned in the [param array] output pin regardless if the [param element] pin value is found and removed.
+        If the [Array] element is removed, the output [param removed] pin will be [code]true[/code], otherwise it will be [code]false[/code].
+    </description>
+</class>

--- a/doc_classes/OScriptNodeArrayRemoveIndex.xml
+++ b/doc_classes/OScriptNodeArrayRemoveIndex.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeArrayRemoveIndex" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Removes an element from an [Array] by the specified index.
+    </brief_description>
+    <description>
+        This node attempts to remove the element at the position specified by the [param index] pin from the [Array] specified by the [param target] pin. The [Array] is returned in the [param array] output pin if the [param index] position is valid. If the [param index] is out of bounds, meaning negative or greater-than or equal-to the size of the [Array], an error occurs.
+    </description>
+</class>

--- a/doc_classes/OScriptNodeArraySet.xml
+++ b/doc_classes/OScriptNodeArraySet.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeArraySet" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Set an element in an array by its index position.
+    </brief_description>
+    <description>
+        This node modifies an existing [Array] by adding the specified element into the [Array] at the given position.
+        The [param array] pin specifies the [Array] that will be modified by this node. The [param index] pin specifies the position within the array where the element is placed. The [param element] pin specifies the element value to be placed into the [Array].
+        If the [param index] position is outside the bounds of the array, the [param size_to_fit] pin can be used to control whether the provided [Array] will be automatically resized so that the write operation succeeds. If [param size_to_fit] is [code]false[/code] and the provided [param index] is out of bounds, an error will occur.
+        The output returns the modified [Array].
+    </description>
+</class>

--- a/doc_classes/OScriptNodeAssignLocalVariable.xml
+++ b/doc_classes/OScriptNodeAssignLocalVariable.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeAssignLocalVariable" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Assigns a value to a local variable.
+    </brief_description>
+    <description>
+        The [OScriptNodeAssignLocalVariable] node is used for assigning a value to a temporary local variable.
+        The [param variable] input pin should be connected with a [OScriptNodeLocalVariable] node, which specifies the variable that is to be assigned. The [param value] input pin specifies the value that should be assigned to the local variable.
+    </description>
+</class>

--- a/doc_classes/OScriptNodeAutoload.xml
+++ b/doc_classes/OScriptNodeAutoload.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeAutoload" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Returns an instance of the specified autoload.
+    </brief_description>
+    <description>
+        An autoload in Godot is similar to a singleton, where there is only ever a singular instance of the object with the given name available. Autoloads are instrumental for providing access to common behavior and data within the scene.
+        The [OScriptNodeAutoload] node returns the autoload instance through the output pin. The specific autoload instance to return is specified by the [param autoload] property in the inspector. When looking for autoloads in the [param All Actions] window, autoloads are listed by their registered name.
+        To register an autoload, go to [b]Project > Project Settings[/b] and select the [b]Global[/b] tab. Under the subtab [b]Autoloads[/b], the specific autoload script can be registered with a unique name. Once registered, the autoload can be picked from the [OScriptNodeAutoload] node's inspector view or by searching for the autoload in the [param All Actions] window.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/autoloads</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeAwaitSignal.xml
+++ b/doc_classes/OScriptNodeAwaitSignal.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeAwaitSignal" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Yields execution of the orchestration until the specified [Signal] is raised.
+    </brief_description>
+    <description>
+        The [OScriptNodeAwaitSignal] node provides coroutine behavior to an orchestration.
+        The node accepts two key input values, the [param target] pin specifies the object that will fire the signal while the [param signal_name] specifies the name of the signal to wait for. When this node executes, it registers a callback for the specified signal, and yields execution back to Godot. Only once the signal is fired will the orchestration resume; otherwise it continues to wait for the signal to be raised.
+        This is quite useful if you need to submit a long-running task to a background thread without blocking the main engine loop. Once the background thread has completed the long-running task, it can schedule the signal to fire on the main thread, causing the orchestration to resume from where it left off.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/signals#await-a-signal</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeBranch.xml
+++ b/doc_classes/OScriptNodeBranch.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeBranch" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Conditionally branches execution flow based on a single condition.
+    </brief_description>
+    <description>
+        The [OScriptNodeBranch] provides a traditional if-else branch style operation. If the [param condition] is [code]true[/code], the node exits through the [param true] output pin, otherwise exits through the [param false] output pin.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/flow-control#branch</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeCallBuiltinFunction.xml
+++ b/doc_classes/OScriptNodeCallBuiltinFunction.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeCallBuiltinFunction" inherits="OScriptNodeCallFunction" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Executes a Godot built-in function.
+    </brief_description>
+    <description>
+        The [OScriptNodeCallBuiltinFunction] node is a specialized [OScriptNodeCallFunction] node that executes one of many Godot built-in functions such as [method str], [method print], and even [method floor]. Many of these functions are found under the [code]Utilities[/code] category in the [param All Actions] window.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/functions#built-in-functions</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeCallFunction.xml
+++ b/doc_classes/OScriptNodeCallFunction.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeCallFunction" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Abstract base class for all nodes that execute different function types.
+    </brief_description>
+</class>

--- a/doc_classes/OScriptNodeCallMemberFunction.xml
+++ b/doc_classes/OScriptNodeCallMemberFunction.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeCallMemberFunction" inherits="OScriptNodeCallFunction" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Executes a Godot class-specific function.
+    </brief_description>
+    <description>
+        The [OScriptNodeCallMemberFunction] node is a specialized [OScriptNodeCallFunction] node that executes one of many Godot functions that are member methods on classes, such as [method Vector3.abs] or [method InputEventKey.get_key_code].
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/functions#calling-functions</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeCallScriptFunction.xml
+++ b/doc_classes/OScriptNodeCallScriptFunction.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeCallScriptFunction" inherits="OScriptNodeCallFunction" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Executes an Orchestration function.
+    </brief_description>
+    <description>
+        The [OScriptNodeCallScriptFunction] node is a specialized [OScriptNodeCallFunction] node that executes a function defined within an [Orchestration].
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/functions#creating-a-function</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeCallStaticFunction.xml
+++ b/doc_classes/OScriptNodeCallStaticFunction.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeCallStaticFunction" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Executes a static function.
+    </brief_description>
+    <description>
+        The [OScriptNodeCallStaticFunction] node is a special node that executes free-standing, static functions. An example is [method FileAccess.exists].
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/functions#calling-functions</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeChance.xml
+++ b/doc_classes/OScriptNodeChance.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeChance" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Picks one of two outputs based on chance.
+    </brief_description>
+    <description>
+        The [OScriptNodeChance] node calculates a value between [code]0[/code] and [code]100[/code] (inclusive). The node will exit the top output pin if the calculated value is between 0 and the top pin's value (inclusive); otherwise, the node will exit the bottom output pin.
+        The node's chance breakpoint is set in the inspector.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/flow-control#chance</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeClassConstant.xml
+++ b/doc_classes/OScriptNodeClassConstant.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeClassConstant" inherits="OScriptNodeClassConstantBase" experimental="This node is experimental and may change in the future." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        A node that provides access to specific constants in Godot classes, such as [code]FOCUS_ALL[/code].
+    </brief_description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/constants#class-specific-constants</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeClassConstantBase.xml
+++ b/doc_classes/OScriptNodeClassConstantBase.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeClassConstantBase" inherits="OScriptNodeConstant" experimental="This node is experimental and may change in the future." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        An abstract base class for all constants that are scoped to a specific class type.
+    </brief_description>
+</class>

--- a/doc_classes/OScriptNodeCoercion.xml
+++ b/doc_classes/OScriptNodeCoercion.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeCoercion" inherits="OScriptNode" deprecated="This node is no longer available." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Provides an implicit conversion between two Godot types.
+    </brief_description>
+    <description>
+        This node provides the Orchestration with an implicit cast between two unique Godot types, such as between [int] and [String]. These nodes are automatically added when connecting two pins that are not compatible but can be coerced (cast to) the target type.
+        [b]Deprecated:[/b] This node is now deprecated and no longer available. An [OScriptNodeTypeCast] node should be used instead to explicitly cast between two types, where needed.
+        [i]This node is scheduled for removal in a future build of Orchestrator.[/i]
+    </description>
+</class>

--- a/doc_classes/OScriptNodeComment.xml
+++ b/doc_classes/OScriptNodeComment.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeComment" inherits="OScriptNode" experimental="This node is experimental and may change in the future." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Provides a comment-based frame around nodes, providing a description for a collection of nodes.
+    </brief_description>
+    <description>
+        The [OScriptNodeComment] is a utility node that allows for providing a graph visual description for what a collection of nodes do.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/comments</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeCompose.xml
+++ b/doc_classes/OScriptNodeCompose.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeCompose" inherits="OScriptNode" deprecated="This node is no longer available." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Compose a [Variant] type based on it's defined constructor arguments.
+    </brief_description>
+    <description>
+        This node creates the specified [Variant] type based on it's constructor arguments.
+        [b]Deprecated:[/b] This node is now deprecated, and replaced by the [OScriptNodeComposeFrom] node.
+        [i]This node is scheduled for removal in a future build of Orchestrator.[/i]
+    </description>
+</class>

--- a/doc_classes/OScriptNodeComposeFrom.xml
+++ b/doc_classes/OScriptNodeComposeFrom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeComposeFrom" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Compose a [Variant] type based on it's defined constructor arguments.
+    </brief_description>
+    <description>
+        This node replaces the old [OScriptNodeCompose] implementation, allowing you to create [Variant] derived types based from various values.
+        For example, this node allows the creation of a [Vector3] from its components of [code]x[/code], [code]y[/code], and [code]z[/code]. Additionally, other variants exist creating a [Vector3] from a [Vector3i] or another [Vector3].
+        This node can be found in the [param All Actions] window using the keywords [code]make[/code], [code]create[/code], or [code]compose[/code].
+    </description>
+</class>

--- a/doc_classes/OScriptNodeConstant.xml
+++ b/doc_classes/OScriptNodeConstant.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeConstant" inherits="OScriptNode" experimental="This node is experimental and may change in the future." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        An abstract base class for all constant-based Orchestrator nodes.
+    </brief_description>
+</class>

--- a/doc_classes/OScriptNodeDecompose.xml
+++ b/doc_classes/OScriptNodeDecompose.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeDecompose" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Breaks a [Variant] type down into its subcomponents.
+    </brief_description>
+    <description>
+        This node allows breaking a given [Variant] type into its subcomponent types.
+        For example, taking a [Vector3] and splitting it into its scalar subcomponents of [code]x[/code], [code]y[/code], and [code]z[/code].
+        This node can be found in the [param All Actions] window using the keywords [code]break[/code], [code]decompose[/code], or [code]split[/code].
+    </description>
+</class>

--- a/doc_classes/OScriptNodeDelay.xml
+++ b/doc_classes/OScriptNodeDelay.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeDelay" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Yields the execution of the orchestration based on the specified delay.
+    </brief_description>
+    <description>
+        The [OScriptNodeDelay] node yields the execution of the control flow based on the specified [param duration] number of seconds.
+        Internally, the node creates a scene-based [Timer] with the specified [param duration], and yields execution. When the [Timer] raises the [code]timeout[/code] signal, the Orchestration resumes where it left off, continuing the execution flow.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/flow-control#delay</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeDialogueChoice.xml
+++ b/doc_classes/OScriptNodeDialogueChoice.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeDialogueChoice" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Specifies a selectable dialogue choice for [OScriptNodeDialogueMessage] nodes.
+    </brief_description>
+    <description>
+        The [OScriptNodeDialogueChoice] node is used conjunction with the [OScriptNodeDialogueMessage] node to create a RPG-based conversation with the player.
+        The [param text] input pin specifies the text to be shown to the user for the option while the [param visible] pin controls whether the choice is visible. These input pins can be combined with other nodes to control the conversation sequence, such as choosing to show an option based on current game state like having a quest or reaching a specific level.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/dialogue#dialogue-choice-node</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeDialogueMessage.xml
+++ b/doc_classes/OScriptNodeDialogueMessage.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeDialogueMessage" inherits="OScriptEditablePinNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Spawns a conversation dialogue to the player.
+    </brief_description>
+    <description>
+        The [OScriptNodeDialogueMessage] node is responsible for spawning a scene overlay on the current playing scene.
+        The [param speaker] input pin specifies the name of the object or character that is initiating the conversation. The [param message] input pin specifies the main dialogue conversation text that should be presented to the player, which represents what the [param speaker] is saying. The [param scene] specifies an optional custom scene to render the conversation. If the [param scene] is left its default of [code]Default Scene[/code], Orchestrator's default simple scene is used instead.
+        The [OScriptNodeDialogueMessage] node can also specify any number of responses that the player can click as part of the conversation. If no choices are specified, its expected the player would be asked to press a continue button to move forward and to exit the node through the output pin. If choice pins are added to the node, each pin should be connected with an [OScriptNodeDialogueChoice] node to specify the properties for that choice. Selecting a choice outputs through the choice's specific output pin instead.
+        [b]NOTE:[/b] See documentation for [OScriptEditablePinNode] for details on how to add/remove choice pins.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/dialogue#show-message-node</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeDictionarySet.xml
+++ b/doc_classes/OScriptNodeDictionarySet.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeDictionarySet" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Adds the specified key/valur pair to a given dictionary, replacing any existing pair with the same key.
+    </brief_description>
+    <description>
+        This node takes the specified [param target] pin [Dictionary] and adds the key/value pair tuple represented by the [param key] and [param value] input pins. The output [param dictionary] pin returns the modified [Dictionary].
+        If the [param key] existed in the [Dictionary], the output [param replaced] pin will be [code]true[/code], otherwise [code]false[/code]. If a value was replaced, the previous [Dictionary] value is output by the [param old value] pin. If no value is replaced, the [param old value] pin returns [code]null[/code].
+    </description>
+</class>

--- a/doc_classes/OScriptNodeEmitMemberSignal.xml
+++ b/doc_classes/OScriptNodeEmitMemberSignal.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeEmitMemberSignal" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Emits a signal on a target object.
+    </brief_description>
+    <description>
+        The [OScriptNodeEmitMemberSignal] node allows for emitting a [Signal] defined on a specific object.
+        The node takes a single input value, the [param object] instance that the signal is emitted for. This is equivalent to:
+        [codeblock]
+        my_obj.emit("my_signal")
+        [/codeblock]
+        The [OScriptNodeEmitMemberSignal] automatically encodes the specific signal being fired and cannot be changed.
+    </description>
+</class>

--- a/doc_classes/OScriptNodeEmitSignal.xml
+++ b/doc_classes/OScriptNodeEmitSignal.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeEmitSignal" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Emits an orchestration signal.
+    </brief_description>
+    <description>
+        The [OScriptNodeEmitSignal] node allows for emitting a [Signal] defined in the orchestration.
+        This is equivalent to:
+        [codeblock]
+        signal my_signal(data: int)
+
+        func _ready():
+          emit_signal("my_signal", 25)
+        [/codeblock]
+        While emitting an orchestration signal can be added using the [param All Actions] window, users can also drag the signal from the [param Signal] component panel onto the orchestration.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/signals#emit-a-signal</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeEngineSingleton.xml
+++ b/doc_classes/OScriptNodeEngineSingleton.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeEngineSingleton" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Returns an instance of the specified Godot engine singleton.
+    </brief_description>
+    <description>
+        The Godot engine has a number of singletons, where there is only a single instance of the object for the Godot engine. There are more than two dozen different singleton types, see the [param Singleton Types] link in [b]Tutorials[/b].
+        The [OScriptNodeEngineSingleton] node returns the singleton instance through the output pin. The specific singleton instance to return is specified by the [param singleton] property in the inspector.
+        All engine singletons are defined in the [param All Actions] window under the [b]Singletons[/b] category.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/singletons</link>
+        <link title="Singletons Types">https://docs.cratercrash.com/orchestrator/nodes/singletons#singleton-types</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeEvent.xml
+++ b/doc_classes/OScriptNodeEvent.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeEvent" inherits="OScriptNodeFunctionEntry" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        A specialized function entry point for Godot event callbacks such as [method _ready].
+    </brief_description>
+    <description>
+        An [OScriptNodeEvent] represents the entrypoint for a Godot event callback. These nodes can only exist within an [param EventGraph], and consist of a single output control flow pin and zero or more output data pins, each which represent arguments to the event function.
+        A specific [OScriptNodeEvent] for a given event callback can only exist within an orchestration once. For example, you cannot define two [OScriptNodeEvent] nodes for [method _ready].
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/events</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeForEach.xml
+++ b/doc_classes/OScriptNodeForEach.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeForEach" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Performs a for-each-loop over an array of elements.
+    </brief_description>
+    <description>
+        The [OScriptNodeForEach] provides a simple for-each-loop mechanism, iterating over each element in an [Array].
+        For each element found in the [param array] input, the node will send an output pulse to the [param loop_body] output pin, allowing your orchestration to perform logic on each array element. Additionally, the node will output the array element through the [param element] output pin, as well as the current position the element is at within the [Array] through the [param index] output pin. The loop ends and outputs an impulse through the [param completed] output pin after all [Array] elements have been iterated.
+        Additionally, the [OScriptNodeForEach] node can be toggled with a [param break] input pin when selecting the [code]For Each with Break[/code] choice in the [param All Actions] window. The [param break] input pin allows the loop's iteration to exit early. The [param break] input pin is usually triggered by having a node in the [param loop_body] connecting its output control flow pin to the [param break] input pin. When control flow passes into the [param break] input pin, the for-each-loop exits immediately.
+        [b]NOTE:[/b] When the for-each-loop breaks early, the node exits the [param aborted] output pin rather than the [param completed] output pin. If its unimportant that the loop exits early, connect both the [param completed] and [param aborted] output pins to the same node.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/flow-control#for-each</link>
+        <link title="Node reference using Break">https://docs.cratercrash.com/orchestrator/nodes/flow-control#for-each-with-break</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeForLoop.xml
+++ b/doc_classes/OScriptNodeForLoop.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeForLoop" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Performs a for-loop based on the difference between the start and end index values.
+    </brief_description>
+    <description>
+        The [OScriptNodeForLoop] provides a simple for-loop mechanism, iterating from start to end, inclusive.
+        The node begins iterating based on the [param start_index] pin's value, and continually increments the counter until it reaches the [param end_index] input pin. For each iteration, the node will send an output pulse to the [param loop_body] output pin, allowing your orchestration to perform logic for each iteration. Additionally, the node will output the current value of the loop index through the [param index] output pin. Once the loop reaches the [param end_index] input pin's value, the loop ends and outputs an impulse through the [param completed] output pin.
+        Additionally, the [OScriptNodeForLoop] node can be toggled with a [param break] input pin when selecting the [code]For Loop with Break[/code] choice in the [param All Actions] window. The [param break] input pin allows the loop's iteration to be broken based on an impulse. The [param break] input pin is usually triggered by having a node in the [param loop_body] connecting its output control flow pin to the [param break] input pin. When control flow passes into the [param break] input pin, the for-loop exits immediately.
+        [b]NOTE:[/b] When the for-loop breaks early, the node exits the [param aborted] output pin rather than the [param completed] output pin. If its unimportant that the loop exits early, connect both the [param completed] and [param aborted] output pins to the same node.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/flow-control#for-loop</link>
+        <link title="Node reference using Break">https://docs.cratercrash.com/orchestrator/nodes/flow-control#for-loop-with-break</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeFree.xml
+++ b/doc_classes/OScriptNodeFree.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeFree" inherits="OScriptNode" experimental="This node is experimental and may change in the future." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Frees the memory used by a Godot object.
+    </brief_description>
+    <description>
+        The [OScriptNodeFree] node accepts a single [param instance] input value that represents the object to be freed.
+        Godot provides two mechanisms for freeing the memory used by an object, they're the [method Object.free] and [method Object.queue_free] methods. The subtle differences on when to use one versus the other can be complicated to understand for newcomers, and [OScriptNodeFree] abstracts that subtle detail away such that you just need to worry with deallocating the object. Internally the node handles whether to use [method Object.free] or [method Object.queue_free] automatically.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/memory#freeing-objects</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeFunctionEntry.xml
+++ b/doc_classes/OScriptNodeFunctionEntry.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeFunctionEntry" inherits="OScriptNodeFunctionTerminator" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Represents the entry point into a user-defined function graph.
+    </brief_description>
+    <description>
+        When creating a function in an orchestration, the function's graph will contain one [OScriptNodeFunctionEntry] node, which is where control is passed into the graph when the function is called. The entry node consists of a single output control flow pin and zero or more output data pins, each which represent an input argument for the function graph.
+        An [OScriptNodeFunctionEntry] node cannot be deleted like other nodes, and will only be removed when the containing function is deleted from the orchestration.
+    </description>
+</class>

--- a/doc_classes/OScriptNodeFunctionResult.xml
+++ b/doc_classes/OScriptNodeFunctionResult.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeFunctionResult" inherits="OScriptNodeFunctionTerminator" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Represents the exit point into a user-defined function graph.
+    </brief_description>
+    <description>
+        When creating a function in an orchestration, the function's graph may contain an [OScriptNodeFunctionResult] node, which is where control is passed back to the caller of the function. The result node will have at least one input control pin and an optional input data pin for passing a single value back to the caller.
+        Multiple [OScriptNodeFunctionResult] can exist in the same function graph if it makes it easier to pass control back to the caller to keep connection wire logic simple and readable.
+        [b]NOTE:[/b] If a [OScriptNodeFunctionResult] node does not exist in the function graph, select the [OScriptNodeFunctionEntry] node in the function graph or select the function in the component panel, and click [param Add Outputs] to add an [OScriptNodeFunctionResult] node.
+    </description>
+</class>

--- a/doc_classes/OScriptNodeFunctionTerminator.xml
+++ b/doc_classes/OScriptNodeFunctionTerminator.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeFunctionTerminator" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        An abstract class that represents a function entry node or return node in a graph.
+    </brief_description>
+</class>

--- a/doc_classes/OScriptNodeGlobalConstant.xml
+++ b/doc_classes/OScriptNodeGlobalConstant.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeGlobalConstant" inherits="OScriptNodeConstant" experimental="This node is experimental and may change in the future." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        A node that outputs a specific global constant, such as [code]KEY_ESCAPE[/code] from the [enum Key] enumeration.
+    </brief_description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/constants#global-constants</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeInputAction.xml
+++ b/doc_classes/OScriptNodeInputAction.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeInputAction" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Returns whether a specific action is pressed, released, just pressed, or just released.
+    </brief_description>
+    <description>
+        The [OScriptNodeInputAction] node allows you to check whether a specific [InputEventAction] has just been pressed, released, or is pressed or released. The specific action to check is defined in the inspector with the [param action] property. The specific state or mode to check is defined in the inspector with the [param mode] property.
+        In GDScript, this is the equivalent to:
+        [codeblock]
+        Input.is_action_just_pressed("ui_left")
+        Input.is_action_pressed("jump")
+        [/codeblock]
+        See [InputEventAction] on how to define input actions in Godot.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/input</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeInstantiateScene.xml
+++ b/doc_classes/OScriptNodeInstantiateScene.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeInstantiateScene" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Instantiates a scene from disk, returning the detached root node of the loaded scene.
+    </brief_description>
+    <description>
+        Instantiating a scene in Godot requires multiple steps, which includes loading the scene resource as a [PackedScene] and then instantiating the scene using the [method PackedScene.instantiate] method. This process requires making sure that the scene resource is successfully loaded and that the scene can be instantiated.
+        The [OScriptNodeInstantiateScene] node handles all the technical details for you. The [param scene] input pin specifies the name of the scene resource to be loaded. The [param scene_root] output pin specifies the root scene node of the detached loaded scene, which can be [code]null[/code] if the scene failed to load.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/scene#instantiating-scenes</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeLocalVariable.xml
+++ b/doc_classes/OScriptNodeLocalVariable.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeLocalVariable" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Provides a variable for storing a temporary value.
+    </brief_description>
+    <description>
+        The [OScriptNodeLocalVariable] node is used for storing a value in a temporary variable location, equivalent to the following:
+        [codeblock]
+        func _process(delta:float):
+          var local_variable = 25
+        [/codeblock]
+        The [OScriptNodeLocalVariable] nodes can only be added to user-defined functions in an orchestration. They are used to store a temporary reference to a value while the function executes. The output pin returns the current value assigned to the local variable. To assign a value to the local variable, use an [OScriptNodeAssignLocalVariable] node.
+    </description>
+</class>

--- a/doc_classes/OScriptNodeMakeArray.xml
+++ b/doc_classes/OScriptNodeMakeArray.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeMakeArray" inherits="OScriptEditablePinNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Create an array from a series of items.
+    </brief_description>
+    <description>
+        This node accepts a variable number of [Variant] input types, adding to the output [Array] in input pin order.
+        [b]NOTE:[/b] See documentation for [OScriptEditablePinNode] for details on how to add/remove output pins.
+    </description>
+</class>

--- a/doc_classes/OScriptNodeMakeDictionary.xml
+++ b/doc_classes/OScriptNodeMakeDictionary.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeMakeDictionary" inherits="OScriptEditablePinNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Create a dictionary from a series of key/value pairs.
+    </brief_description>
+    <description>
+        This node accepts a variable number of [Variant] key/valur pairs, adding the pair to the output [Dictionary].
+        [b]NOTE:[/b] See documentation for [OScriptEditablePinNode] for details on how to add/remove output pins. A key/value pair can be removed by right-clicking either the [code]Key n[/code] or the [code]Value n[/code] pin for the tuple, where [code]n[/code] is 0 or higher.
+    </description>
+</class>

--- a/doc_classes/OScriptNodeMathConstant.xml
+++ b/doc_classes/OScriptNodeMathConstant.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeMathConstant" inherits="OScriptNodeConstant" experimental="This node is experimental and may change in the future." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        A node that outputs a specific math constant, such as [code]PI[/code] or [code]TAU[/code].
+    </brief_description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/constants#math-specific-constants</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeNew.xml
+++ b/doc_classes/OScriptNodeNew.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeNew" inherits="OScriptNode" experimental="This node is experimental and may change in the future." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Creates a new instance of a specific object type.
+    </brief_description>
+    <description>
+        The [OScriptNodeNew] node creates a new instance of a specific object type, similar to using GDScript's [method Object.new] method.
+        The object type that will be created is specified by modifying the [param class_name] property in the inspector.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/memory#creating-objects</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeOperator.xml
+++ b/doc_classes/OScriptNodeOperator.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeOperator" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Executes a specific mathematical operation between one or two operands.
+    </brief_description>
+    <description>
+        The [OScriptNodeOperator] node is a mega node that takes one or two operands and performs a specific mathematical operation on the input values.
+        For unary operations, a single input parameter named [param a] is used to pass the value into node. The node performs the operation and outputs the final result in the [param result] output pin.
+        For binary operations, two input parameters named [param a] and [param b] are used to pass values into the node. The node performs the operation and outputs the final result in the [param result] output pin.
+        [b]NOTE:[/b] The operation and argument types are determined when adding the operation node to the graph. If the operand types or operation need to change, you will need to add a new operator node to the graph.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/math</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodePreload.xml
+++ b/doc_classes/OScriptNodePreload.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodePreload" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Preloads a resource while the Orchestration is being initialized.
+    </brief_description>
+    <description>
+        The [OScriptNodePreload] node will automatically load the specified resource when the orchestration script is being loaded. The [param resource] can be specified in the inspector, and will be returned in the output pin.
+        This node works similar to [method @GDScript.preload] in GDScript:
+        [codeblock]
+        var my_data = preload("res://my_data.tres")
+        [/codeblock]
+        In an orchestration, the resource will be loaded once at script load time so that its available immediately during the script's runtime.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/resources#preload-resources</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodePrintString.xml
+++ b/doc_classes/OScriptNodePrintString.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodePrintString" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Prints the specified string, optionally to the screen and/or the console.
+    </brief_description>
+    <description>
+        The [OScriptNodePrintString] node is a utility node for writing string output optionally to the screen and/or the console.
+        The [param text] input pin is the text that will be added to the screen and/or the console. When the [param print_to_screen] input pin is set to [code]true[/code], the text is rendered to the screen. When the [param print_to_log] is set to [code]true[/code], the text is appended to the console output.
+        When the [param text] is rendered to the screen, the [param text_color] defines the color that the text will be rendered using. Additionally, the [param duration] specifies the length of time the text will be displayed before disappearing.
+        The [OScriptNodePrintString] node is useful for debugging because the node will be omitted from export builds, so that no data is printed to the screen nor the console. In other words, this node only works inside the editor and is skipped when exporting games for distribution.
+    </description>
+</class>

--- a/doc_classes/OScriptNodeProperty.xml
+++ b/doc_classes/OScriptNodeProperty.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeProperty" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        The abstract base class for property accessor (getter) and mutators (setters).
+    </brief_description>
+</class>

--- a/doc_classes/OScriptNodePropertyGet.xml
+++ b/doc_classes/OScriptNodePropertyGet.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodePropertyGet" inherits="OScriptNodeProperty" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Returns the value of a specific object property.
+    </brief_description>
+    <description>
+        The [OScriptNodePropertyGet] node is used to return the value of a property.
+        The node can be used with three specific modes, [code]self[/code], [code]instance[/code], and [code]node path[/code].
+        [b]Self mode:[/b][br]When the node operates in [i]self mode[/i], the property that is being returned exists on the orchestration's base class type or one of its super types. The value of the property will be returned by the output pin. The property cannot be changed once the node is placed and requires adding a new node if the property needs to change.
+        [b]Instance mode:[/b][br]When the node operates in [i]instance mode[/i], the property node takes an object instance as an input argument and returns the value of the property from that object. The value of the property will be returned by the output pin. The property cannot be changed once the node is placed and requires adding a new node if the property needs to change.
+        [b]NodePath mode:[/b][br]When the node operates in [i]node path mode[/i], the property is resolved using a [NodePath] argument. The value of the property is returned by the output pin. The [NodePath] and property cannot be changed once the node is placed and requires adding the reference again if either change.
+        [i]This specific node implementation will be expanded in a future build to relax the placement restrictions and to make working with properties significantly easier.[/i]
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/properties#get-property</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodePropertySet.xml
+++ b/doc_classes/OScriptNodePropertySet.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodePropertySet" inherits="OScriptNodeProperty" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Sets the value for a specific object property.
+    </brief_description>
+    <description>
+        The [OScriptNodePropertySet] node is used to set the value of a property.
+        The node can be used with three specific modes, [code]self[/code], [code]instance[/code], and [code]node path[/code].
+        [b]Self mode:[/b][br]When the node operates in [i]self mode[/i], the property that is being modified exists on the orchestration's base class type or one of its super types. The value to set is specified on the input value pin. The property cannot be changed once the node is placed and requires adding a new node if the property needs to change.
+        [b]Instance mode:[/b][br]When the node operates in [i]instance mode[/i], the property node takes an object instance as an input argument and the property value to be set on the object. The property cannot be changed once the node is placed and requires adding a new node if the property needs to change.
+        [b]NodePath mode:[/b][br]When the node operates in [i]node path mode[/i], the property is resolved using a [NodePath] argument. The value to set is specified on the input value pin. The [NodePath] and property cannot be changed once the node is placed and requires adding the reference again if either change.
+        [i]This specific node implementation will be expanded in a future build to relax the placement restrictions and to make working with properties significantly easier.[/i]
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/properties#set-property</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeRandom.xml
+++ b/doc_classes/OScriptNodeRandom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeRandom" inherits="OScriptEditablePinNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Randomly picks one of the output choices.
+    </brief_description>
+    <description>
+        The [OScriptNodeRandom] node allows you to specify one or more output choices, picking one of the output choices at random. Each output pin has equal chance to be picked.
+        [b]NOTE:[/b] See documentation for [OScriptEditablePinNode] for details on how to add/remove random choice pins.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/flow-control#random</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeResourcePath.xml
+++ b/doc_classes/OScriptNodeResourcePath.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeResourcePath" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Returns the path for a given resource.
+    </brief_description>
+    <description>
+        The [OScriptNodeResourcePath] node returns the path associated with a specific resource. The [param path] can be specified in the inspector, and will be returned in the output pin.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/resources#resource-paths</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeSceneNode.xml
+++ b/doc_classes/OScriptNodeSceneNode.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeSceneNode" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Returns a reference to a scene node by [NodePath].
+    </brief_description>
+    <description>
+        The [OScriptNodeSceneNode] returns a reference a scene node using the specified [NodePath].
+        An [OScriptNodeSceneNode] can be created by dragging a scene node from the editor's scene tree dock onto the orchestration graph canvas. If the [NodePath] associated with the node needs to be adjusted, the [param node_path] property can be modified in the inspector. If the scene node cannot be found in the scene at runtime, the node returns [code]null[/code].
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/scene#scene-nodes</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeSceneTree.xml
+++ b/doc_classes/OScriptNodeSceneTree.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeSceneTree" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Returns a reference to the top-level [SceneTree].
+    </brief_description>
+    <description>
+        The [OScriptNodeSceneTree] returns a reference to the top-level [SceneTree].
+        The [SceneTree] instance is useful for creating various scene-specific objects such as [Timer]s or [Tween]s. If your orchestration base type extends [Node], you can also directly access the [SceneTree] using the [method Node.get_tree] method.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/scene#scene-tree</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeSelect.xml
+++ b/doc_classes/OScriptNodeSelect.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeSelect" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Select between two inputs based on a condition.
+    </brief_description>
+    <description>
+        The [OScriptNodeSelect] node accepts two inputs using the [param a] and [param b] input pins. When the [param pick_a] input pin is [code]true[/code], the value of [param a] is returned in the [param result] output pin. When [param pick_a] input pin is [code]false[/code], the value of [param b] is returned in the [param result] output pin.
+        By default, the [OScriptNodeSelect] specifies that the [param a], [param b], and [param result] pins accept and output [Variant] types; however, you can customize the node to use a specific type by right-clicking any one of those pins. In the change pin type context-menu, select any available type to change the pin's type to limit what values can be connected to the pins.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/flow-control#select</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeSelf.xml
+++ b/doc_classes/OScriptNodeSelf.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeSelf" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Returns a reference to the node that the orchestration is attached.
+    </brief_description>
+    <description>
+        The [OScriptNodeSelf] node returns a reference to the node that orchestration is attached to, equivalent to using python's [code]self[/code] keyword.
+        This node is a short-cut node for adding a [OScriptNodeSceneNode] that uses the [code].[/code] [NodePath] to refer to [code]this[/code].
+    </description>
+</class>

--- a/doc_classes/OScriptNodeSequence.xml
+++ b/doc_classes/OScriptNodeSequence.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeSequence" inherits="OScriptEditablePinNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        The sequence node allows for a single input pulse to trigger the execution of two or more events in sequence.
+    </brief_description>
+    <description>
+        The sequence node may have two or more outputs, of which all are called as soon as the [code]Sequence[/code] node receives the input. They will always get called in order, but without any delay.
+        [b]NOTE:[/b] See documentation for [OScriptEditablePinNode] for details on how to add/remove output pins.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/flow-control#sequence</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeSingletonConstant.xml
+++ b/doc_classes/OScriptNodeSingletonConstant.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeSingletonConstant" inherits="OScriptNodeClassConstantBase" experimental="This node is experimental and may change in the future." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        A node that provides access to specific constants on Godot singletons, such as [code]MOUSE_MODE_VISIBLE[/code].
+    </brief_description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/constants#singleton-specific-constants</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeSwitch.xml
+++ b/doc_classes/OScriptNodeSwitch.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeSwitch" inherits="OScriptEditablePinNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Provides a simple match/switch based construct for varying control flow based on comparisons.
+    </brief_description>
+    <description>
+        The [OScriptNodeSwitch] node accepts a value in the [param value] input pin and compares it to one of the [param case_n] input pins, if specified. If a [param case_n] value matches [param value], it's associated output control flow pin will be the exit point for the node. If none of the [param case_n] input values match, the node exits through the [param default] output pin. Once the [param case_n] or [param default] output pin's logic has completed, the control returns back to the [OScriptNodeSwitch] node where it will send a final output pulse to the [param done] output pin.
+        This node can be extremely useful in if-elseif-else logic operations, as shown here in GDScript:
+        [codeblock]
+        func my_function():
+          if value == 12345:
+            # exits the case where the value 12345 is connected
+          elif value == 67890:
+            # exits the case where the value 67890 is connected
+          else:
+            # exits the default output pin
+
+          # exits the done pin, passing control to the next part of the logic
+          print("Hello World")
+        [/codeblock]
+        [b]NOTE:[/b] See documentation for [OScriptEditablePinNode] for details on how to add/remove case input/output pins.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/flow-control#switch</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeSwitchEditablePin.xml
+++ b/doc_classes/OScriptNodeSwitchEditablePin.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeSwitchEditablePin" inherits="OScriptEditablePinNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        An abstract class that provides extended editable pin behavior for switch-based nodes.
+    </brief_description>
+    <description>
+        [b]NOTE:[/b] See documentation for [OScriptEditablePinNode] for details on how to add/remove pins.
+    </description>
+</class>

--- a/doc_classes/OScriptNodeSwitchEnum.xml
+++ b/doc_classes/OScriptNodeSwitchEnum.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeSwitchEnum" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Provides match/switch based logic for enum types.
+    </brief_description>
+    <description>
+        The [OScriptNodeSwitchEnum] node accepts a value in the [param value] input pin and compares to the values of the specific enumeration type.
+        If the [param value] input matches an output pin, the node exits through that specific output pin. This can be useful if you want different behavior to be executed based on a specific value, such as a key press.
+        [codeblock]
+        func _unhandled_key_input(input: InputEventKey):
+          if input.is_pressed():
+            match input.keycode:
+              KEY_ESCAPE:
+                # handles when the ESCAPE key is pressed
+              KEY_SPACE:
+                # handles when the SPACE key is pressed
+        [/codeblock]
+        In the prior GDScript code block, an [OScriptNodeSwitchEnum] node can represent the [code]match[/code] operation. By adding a [code]Switch on Key[/code] node and connecting the input event's [code]keycode[/code] value into the [param value] input pin and adding output connections on the [code]Escape[/code] and [code]Space[/code] output pins, the above [code]match[/code] can be represented in an orchestration.
+    </description>
+</class>

--- a/doc_classes/OScriptNodeSwitchInteger.xml
+++ b/doc_classes/OScriptNodeSwitchInteger.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeSwitchInteger" inherits="OScriptNodeSwitchEditablePin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Provides match/switch based logic for integer values.
+    </brief_description>
+    <description>
+        The [OScriptNodeSwitchInteger] node accepts a value in the [param value] input pin and compares it to name of the output pins, if any exist.
+        Output pins can be added to the node using the [code]+[/code] button. The names for output pins are based on the [param start_index], which can be set in the inspector. If the name of an output pin matches the [param value] input pin value, the node exits through that specific output pin. If none of the output pins match, the [param default] output pin will be used at the exit point.
+        Additionally, the [param default] output pin can be disabled in the inspector. When the [param default] output pin is disabled and none of the output pin names match the input value, execution ends.
+        [b]NOTE:[/b] See documentation for [OScriptNodeSwitchEditablePin] for details on how to add/remove case input/output pins.
+    </description>
+</class>

--- a/doc_classes/OScriptNodeSwitchString.xml
+++ b/doc_classes/OScriptNodeSwitchString.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeSwitchString" inherits="OScriptNodeSwitchEditablePin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Provides match/switch based logic for string values.
+    </brief_description>
+    <description>
+        The [OScriptNodeSwitchString] node accepts a value in the [param value] input pin and compares it to name of the [param case_n] output pins, if any exist.
+        Output pins can be added to the node using the [code]+[/code] button. The names for output pins can be customized in the inspector. If the name of an output pin matches the [param value] input pin value, the node exits through that specific output pin. If none of the output pins match, the [param default] output pin will be used at the exit point. If the comparison should be case-sensitive, toggle the [param case_sensitive] option in the inspector.
+        Additionally, the [param default] output pin can be disabled in the inspector. When the [param default] output pin is disabled and none of the output pin names match the input value, execution ends.
+        [b]NOTE:[/b] See documentation for [OScriptNodeSwitchEditablePin] for details on how to add/remove case input/output pins.
+    </description>
+</class>

--- a/doc_classes/OScriptNodeTypeCast.xml
+++ b/doc_classes/OScriptNodeTypeCast.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeTypeCast" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        A node that allows explicitly casting from one Godot type to another.
+    </brief_description>
+    <description>
+        The [OScriptNodeTypeCast] node takes a [Variant] in the [param instance] pin, and attempts to convert the instance to the desired type. The type is selected from within the inspector.
+        If the type cast is successful, the node exits through the [param yes] output pin, returning the cast object in the output instance pin. If the type cast fails, the node exits through the [param no] output pin, with the output instance pin as [code]null[/code].
+        There are multiple use cases where Godot will provide a value as a [Variant] or as a super class type, such as [InputEvent]. When dragging from an orchestration node pin that uses such types, you won't get the same context-sensitive detail about properties, methods, or signals for the concrete types these represent without first applying a cast operation. In GDScript, you would do something like the following:
+        [codeblock]
+        func _unhandled_input(event: InputEvent):
+          if event is InputEventKey:
+            var key_event := event as InputEventKey
+            if key_event.keycode == KEY_ESCAPE:
+              get_tree().quit()
+        [/codeblock]
+        In this example, the [code]is[/code] keyword is used to check whether the [param event] is of the desired type [InputEventKey]. If that is [code]true[/code], the code then casts the [param event] argument to [InputEventKey] using the [code]as[/code] keyword, allowing the code to access the [code]keycode[/code] property on [InputEventKey].
+        GDScript uses what is called duck-typing, meaning that these casts are unnecessary for runtime; however, if you want the script editor to provide you with context-sensitive details about the properties, methods, and signals related to an argument, this is necessary.
+        The [OScriptNodeTypeCast] node encapsulates the above behind into a single logical step.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/flow-control#type-cast</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeTypeConstant.xml
+++ b/doc_classes/OScriptNodeTypeConstant.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeTypeConstant" inherits="OScriptNodeConstant" experimental="This node is experimental and may change in the future." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        A node that outputs a specific constant from a Godot built-in type, such as [Vector3].
+    </brief_description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/constants#type-specific-constants</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeVariable.xml
+++ b/doc_classes/OScriptNodeVariable.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeVariable" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        The abstract base class for variable accessor (getter) and mutators (setters).
+    </brief_description>
+</class>

--- a/doc_classes/OScriptNodeVariableGet.xml
+++ b/doc_classes/OScriptNodeVariableGet.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeVariableGet" inherits="OScriptNodeVariable" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Returns the value of a specific orchestration variable.
+    </brief_description>
+    <description>
+        The [OScriptNodeVariableGet] node is used to return the value of an orchestration variable.
+        The output pin returns the value currently assigned in the orchestration variable. If the variable has not been assigned, it will return the variable type's default value, which may be [code]null[/code].
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/variables#get-nodes</link>
+        <link title="Variables reference">https://docs.cratercrash.com/orchestrator/nodes/variables</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeVariableSet.xml
+++ b/doc_classes/OScriptNodeVariableSet.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeVariableSet" inherits="OScriptNodeVariable" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Sets the value of a specific orchestration variable.
+    </brief_description>
+    <description>
+        The [OScriptNodeVariableSet] node is used to set the value of an orchestration variable.
+        The input pin sets the value to the orchestration variable. The output data pin will return the newly assigned value.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/variables#set-nodes</link>
+        <link title="Variables reference">https://docs.cratercrash.com/orchestrator/nodes/variables</link>
+    </tutorials>
+</class>

--- a/doc_classes/OScriptNodeWhile.xml
+++ b/doc_classes/OScriptNodeWhile.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OScriptNodeWhile" inherits="OScriptNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+    <brief_description>
+        Provides a simple while-loop based on a condition.
+    </brief_description>
+    <description>
+        The [OScriptNodeWhile] node continuously executes the logic connected to the [param repeat] output pin while the [param condition] input pin is [code]true[/code]. When the [param condition] input pin is [code]false[/code], the while loop exits through the [param done] output pin.
+    </description>
+    <tutorials>
+        <link title="Node reference">https://docs.cratercrash.com/orchestrator/nodes/flow-control#while</link>
+    </tutorials>
+</class>


### PR DESCRIPTION
Fixes #610 

The hook was only added as part of `godot-cpp` 4.3:
https://github.com/godotengine/godot-cpp/commit/a434850069212b2d2dbe70fd82c4e5774b739040
