### PR TITLE
GH-617 Retain `PrintString` defaults across node refreshes

### DIFF
--- a/src/script/nodes/utilities/print_string.cpp
+++ b/src/script/nodes/utilities/print_string.cpp
@@ -210,6 +210,21 @@ String OScriptNodePrintString::get_tooltip_text() const
                    "If Print To Log is true, it will be shown in the output window.");
 }
 
+void OScriptNodePrintString::reallocate_pins_during_reconstruction(const Vector<Ref<OScriptNodePin>>& p_old_pins)
+{
+    super::reallocate_pins_during_reconstruction(p_old_pins);
+
+    for (const Ref<OScriptNodePin>& pin : p_old_pins)
+    {
+        if (pin->is_input() && !pin->is_execution())
+        {
+            Ref<OScriptNodePin> new_pin = find_pin(pin->get_pin_name(), PD_Input);
+            if (new_pin.is_valid())
+                new_pin->set_default_value(pin->get_effective_default_value());
+        }
+    }
+}
+
 OScriptNodeInstance* OScriptNodePrintString::instantiate()
 {
     OScriptNodePrintStringInstance* i = memnew(OScriptNodePrintStringInstance);

--- a/src/script/nodes/utilities/print_string.h
+++ b/src/script/nodes/utilities/print_string.h
@@ -41,6 +41,7 @@ public:
     String get_node_title() const override { return "Print String"; }
     String get_node_title_color_name() const override { return "function_call"; }
     String get_icon() const override { return "MemberMethod"; }
+    void reallocate_pins_during_reconstruction(const Vector<Ref<OScriptNodePin>>& p_old_pins) override;
     OScriptNodeInstance* instantiate() override;
     //~ End OScriptNode Interface
 


### PR DESCRIPTION
Fixes #617 